### PR TITLE
Alpha gate: documentation and templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+
+- What changed:
+- Why:
+
+## Public/Private Review (required)
+
+- [ ] I ran `agentmesh classify --staged --fail-on-private --fail-on-review` and it passed.
+- [ ] I ran `agentmesh release-check --staged --json` and it passed.
+- [ ] No raw private run artifacts are included (CI logs, raw canary reports, internal strategy docs).
+- [ ] If any docs were added/updated, they are sanitized for OSS publication.
+
+## Validation
+
+- [ ] Tests updated/added where needed.
+- [ ] Local test run completed (`uv run pytest -q` or targeted equivalent).
+
+## Notes
+
+- Risks / follow-ups:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This repo uses AgentMesh as a local coordination + provenance layer around norma
 2. Use `agentmesh task finish` for commits that should carry provenance.
 3. If `task` wrappers are not used, at minimum use `agentmesh commit` instead of plain `git commit`.
 4. In multi-agent runs, claim resources before editing.
+5. Before publishing docs/artifacts, run `agentmesh classify --staged --json` and resolve all `private`/`review` results.
+6. Before release/PR finalization, run `agentmesh release-check --staged --json`.
 
 ## Happy Path (Humans + Agents)
 
@@ -48,3 +50,12 @@ agentmesh episode end
 - `agentmesh weave trace <path>` shows provenance events touching a file.
 - `agentmesh weave verify` checks chain integrity.
 - `agentmesh episode export <episode_id>` creates a portable `.meshpack`.
+
+## Public vs Private Guardrail
+
+- `agentmesh classify --staged` classifies staged files as `public`, `private`, or `review`.
+- `agentmesh release-check --staged --json` runs classifier + weave verification (+ optional witness/tests) with strict exit codes.
+- `agentmesh sanitize-alpha-gate-report --in <private_json> --out <public_json>` converts private gate outputs to publishable artifacts.
+- `private` means keep out of OSS unless fully sanitized.
+- `review` means manual decision required before publishing.
+- Use `agentmesh classify --staged --fail-on-private --fail-on-review` in release prep.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,40 @@ jobs:
 
 The action posts a sticky PR comment showing commit coverage. Set `require-trailers: "true"` to enforce episode lineage, and `verify-witness: "true"` + `require-witness: "true"` to enforce cryptographic witness verification.
 
+## Documentation Policy
+
+- Public/private split guidance: [`docs/public-private-boundary.md`](./docs/public-private-boundary.md)
+- Decision matrix + release gate: [`docs/public-private-decision-matrix.md`](./docs/public-private-decision-matrix.md)
+- Alpha gate operator runbook: [`docs/alpha-gate-runbook.md`](./docs/alpha-gate-runbook.md)
+- License transition policy: [`docs/license-policy.md`](./docs/license-policy.md)
+
+Generated canary artifacts (CI logs, raw gate reports) should be treated as private by default. Publish sanitized summaries/templates for OSS.
+
+Use the classifier before publishing:
+
+```bash
+agentmesh classify --staged --fail-on-private --fail-on-review
+```
+
+Release preflight (deterministic gate for agents/automation):
+
+```bash
+agentmesh release-check --staged --require-witness --json
+```
+
+Sanitize private alpha gate artifacts before publishing:
+
+```bash
+agentmesh sanitize-alpha-gate-report \
+  --in .agentmesh/runs/alpha-gate-report.json \
+  --out docs/alpha-gate-report.public.json
+```
+
+CI rollout recommendation:
+- Start with non-blocking `release-check` preview artifacts.
+- Keep private-artifact blocking enabled.
+- Switch `release-check` to blocking after policy tuning.
+
 ## License
 
 AgentMesh is licensed under Apache-2.0 for current and future development.

--- a/docs/alpha-gate-report.md
+++ b/docs/alpha-gate-report.md
@@ -1,0 +1,91 @@
+# Alpha Gate Report (Sanitized Implementation Summary)
+
+This document is safe for public OSS documentation.
+
+- It summarizes capabilities and checks.
+- It does **not** embed sensitive canary internals.
+- Raw run artifacts should remain private (see [`public-private-boundary.md`](./public-private-boundary.md)).
+
+## Implemented Items
+
+1. **Orchestrator lease lock**
+   - Added orchestration lease control via typed lock claim (`LOCK:orchestration`).
+   - Mutating control-plane commands now acquire/release lease with fail-fast conflict handling.
+   - `--json` lock conflicts emit structured error payload.
+   - `orch abort-all` force-clears orchestration lease locks.
+
+2. **Adapter trust boundary hardening**
+   - Added adapter allowlist policy gate (`worker_adapters.allow_backends|allow_modules|allow_paths`).
+   - Disabled env-based adapter autoload when `CI=true`.
+   - Added structured adapter metadata logging (`ADAPTER_LOAD` event with backend/module/origin/version).
+   - Disallowed adapters fail closed in spawn path.
+
+3. **Cost budget enforcement**
+   - Added task-level `--max-cost-usd` (stored in task meta).
+   - Watchdog enforces cumulative cost from `WORKER_DONE` events.
+   - Over-budget tasks emit weave receipt + `COST_EXCEEDED` event and are aborted.
+
+4. **Emergency controls**
+   - Added `agentmesh orch freeze` / `--off`.
+   - Added `agentmesh orch lock-merges` / `--off`.
+   - Added `agentmesh orch abort-all --reason ...`.
+   - Enforcement:
+     - Spawns blocked while frozen.
+     - `REVIEW_PASS -> MERGED` blocked while merges are locked.
+
+5. **Observability**
+   - Added `agentmesh orch watch` with polling stream.
+   - `--json` mode outputs JSON lines for task/spawn/watchdog/merge-control events.
+
+6. **Alpha gate harness**
+   - Added machine-report module: `src/agentmesh/alpha_gate.py`
+   - Added CLI script: `scripts/alpha_gate_report.py`
+   - Added operator runbook: `docs/alpha-gate-runbook.md`
+   - Gate report utility for machine output (store raw output in private artifact path)
+
+## Gate Check Results
+
+Source: deterministic local harness run (sanitized summary)
+
+| Check | Result |
+|---|---|
+| merged task count >= 1 | PASS |
+| witness VERIFIED in CI path | PASS |
+| full transition receipts present | PASS |
+| watchdog handled >= 1 event | PASS |
+| no orphan/finalization loss | PASS |
+
+## Validation Commands
+
+```bash
+cd /path/to/agentmesh
+uv run pytest -q tests/test_orch_cli.py tests/test_spawner.py tests/test_watchdog.py tests/test_orchestrator.py tests/test_alpha_gate.py tests/test_worker_cli.py tests/test_watchdog_cli.py
+uv run pytest -q
+uv run python - <<'PY'
+from pathlib import Path
+from agentmesh import db, events, orchestrator
+from agentmesh.models import Agent, TaskState, EventKind, _now
+from agentmesh.alpha_gate import write_alpha_gate_report
+data_dir = Path('tmp_alpha_gate_data')
+data_dir.mkdir(exist_ok=True)
+db.init_db(data_dir)
+db.register_agent(Agent(agent_id='alpha_agent', cwd='/tmp'), data_dir)
+t = orchestrator.create_task('alpha demo', data_dir=data_dir)
+orchestrator.assign_task(t.task_id, 'alpha_agent', branch='feat/alpha-demo', data_dir=data_dir)
+orchestrator.transition_task(t.task_id, TaskState.RUNNING, data_dir=data_dir)
+orchestrator.transition_task(t.task_id, TaskState.PR_OPEN, data_dir=data_dir)
+orchestrator.transition_task(t.task_id, TaskState.CI_PASS, data_dir=data_dir)
+orchestrator.transition_task(t.task_id, TaskState.REVIEW_PASS, data_dir=data_dir)
+orchestrator.complete_task(t.task_id, agent_id='alpha_agent', data_dir=data_dir)
+db.create_spawn('spawn_alpha', t.task_id, 'att_alpha', 'alpha_agent', 123, '/tmp/wt', 'feat/alpha-demo', '', 'sha256:abc', _now(), data_dir=data_dir)
+db.update_spawn('spawn_alpha', ended_at=_now(), outcome='success', data_dir=data_dir)
+events.append_event(EventKind.GC, payload={'watchdog':'scan','harvested_spawns':['spawn_alpha']}, data_dir=data_dir)
+write_alpha_gate_report(Path('.agentmesh/runs/alpha-gate-report.json'), data_dir, ci_log_text='VERIFIED', require_witness_verified=True)
+PY
+```
+
+## Residual Risks
+
+1. **Lease is CLI-process scoped**: this prevents concurrent mutating controllers, but long-lived external orchestrator daemons should keep renewing lease by design (future enhancement).
+2. **Cost enforcement is event-driven**: budget checks depend on emitted `WORKER_DONE` metrics and can only enforce on known cumulative spend.
+3. **Witness gate in report depends on CI log input**: report correctness for witness status requires passing real CI output.

--- a/docs/alpha-gate-report.template.json
+++ b/docs/alpha-gate-report.template.json
@@ -1,0 +1,32 @@
+{
+  "overall_pass": false,
+  "checks": {
+    "merged_task_count": {
+      "pass": false,
+      "actual": 0,
+      "expected_min": 1
+    },
+    "witness_verified_ci": {
+      "pass": false,
+      "required": true,
+      "source": "ci_result"
+    },
+    "full_transition_receipts": {
+      "pass": false,
+      "missing_tasks": [],
+      "state_mismatch_tasks": []
+    },
+    "watchdog_handled_event": {
+      "pass": false
+    },
+    "no_orphan_finalization_loss": {
+      "pass": true,
+      "bad_spawns": []
+    }
+  },
+  "summary": {
+    "tasks_total": 0,
+    "events_total": 0,
+    "spawns_total": 0
+  }
+}

--- a/docs/alpha-gate-runbook.md
+++ b/docs/alpha-gate-runbook.md
@@ -1,0 +1,101 @@
+# Alpha Gate Runbook
+
+This runbook executes a single-task orchestrated run and emits a machine-readable gate report.
+
+## Artifact Handling Policy
+
+- Treat raw canary artifacts as **private** by default.
+- Store raw outputs outside public docs (example path used below: `.agentmesh/runs/`).
+- Publish only sanitized summaries in OSS docs.
+
+## Prereqs
+
+- Local repo initialized with `agentmesh init`
+- Hooks installed if using Claude Code (`agentmesh hooks install`)
+- Witness deps installed if strict witness checks are required:
+
+```bash
+pip install "agentmesh-core[witness]"
+```
+
+## 1) Start with a clean control plane
+
+```bash
+agentmesh orch abort-all --reason "alpha gate reset"
+agentmesh orch freeze --off
+agentmesh orch lock-merges --off
+```
+
+If you're running a long-lived external orchestrator loop, renew lease periodically:
+
+```bash
+agentmesh orch lease-renew --owner "$AGENTMESH_ORCH_OWNER" --ttl 300 --json
+```
+
+## 2) Create and assign one task
+
+```bash
+TASK_ID=$(agentmesh --data-dir "$AGENTMESH_DATA_DIR" orch create \
+  --title "Alpha gate canary task" \
+  --description "One real orchestrated PR run" \
+  --max-cost-usd 2.50 \
+  --json | jq -r .task_id)
+
+agentmesh --data-dir "$AGENTMESH_DATA_DIR" orch assign "$TASK_ID" --branch feat/alpha-gate --json
+```
+
+## 3) Spawn a worker
+
+```bash
+SPAWN_ID=$(agentmesh --data-dir "$AGENTMESH_DATA_DIR" worker spawn "$TASK_ID" \
+  --backend claude_code --json | jq -r .spawn_id)
+```
+
+## 4) Monitor and harvest
+
+```bash
+agentmesh --data-dir "$AGENTMESH_DATA_DIR" orch watch --json
+agentmesh --data-dir "$AGENTMESH_DATA_DIR" watchdog --json
+agentmesh --data-dir "$AGENTMESH_DATA_DIR" worker harvest "$SPAWN_ID" --json
+```
+
+## 5) Advance to merged (if policy gates are satisfied)
+
+```bash
+agentmesh --data-dir "$AGENTMESH_DATA_DIR" orch advance "$TASK_ID" --to ci_pass --json
+agentmesh --data-dir "$AGENTMESH_DATA_DIR" orch advance "$TASK_ID" --to review_pass --json
+agentmesh --data-dir "$AGENTMESH_DATA_DIR" orch advance "$TASK_ID" --to merged --json
+```
+
+## 6) Generate Alpha Gate report
+
+```bash
+python scripts/alpha_gate_report.py \
+  --data-dir "$AGENTMESH_DATA_DIR" \
+  --ci-result-json ./.agentmesh/runs/ci-result.json \
+  --ci-log ./.agentmesh/runs/ci-witness.log \
+  --out ./.agentmesh/runs/alpha-gate-report.json
+```
+
+If CI log is not available locally:
+
+```bash
+python scripts/alpha_gate_report.py \
+  --data-dir "$AGENTMESH_DATA_DIR" \
+  --witness-optional \
+  --out ./.agentmesh/runs/alpha-gate-report.json
+```
+
+## Required checks in report
+
+- `merged_task_count.pass == true`
+- `witness_verified_ci.pass == true` (unless witness optional mode was used)
+- `full_transition_receipts.pass == true`
+- `watchdog_handled_event.pass == true`
+- `no_orphan_finalization_loss.pass == true`
+
+## Public Output Pattern
+
+- Keep full JSON report private.
+- Publish sanitized summary in markdown (without sensitive repo/CI details).
+- If you need a public JSON example, use [`docs/alpha-gate-report.template.json`](./alpha-gate-report.template.json) rather than a real run artifact.

--- a/docs/public-private-boundary.md
+++ b/docs/public-private-boundary.md
@@ -1,0 +1,81 @@
+# Public vs Private Boundary
+
+This project uses an intentional split:
+
+- **Public OSS (AgentMesh repo)** drives adoption, trust, and install growth.
+- **Private operations + strategy (CCIO/internal)** preserve commercial leverage.
+
+## Public (safe to ship in OSS)
+
+- Core runtime capabilities:
+  - orchestration lease lock/renew
+  - freeze / lock-merges / abort-all controls
+  - spawner/watchdog hardening
+  - adapter allowlist policy gates
+  - task cost budgets
+  - independent test-isolation verification
+  - dependency DAG + cycle checks
+- Tests for the above behavior.
+- Generic docs/runbooks without sensitive repo or customer context.
+- CI integration docs and `agentmesh-action` usage.
+
+## Private (keep internal)
+
+- GTM, pricing, positioning, and competitive strategy.
+- Internal planning docs and sequencing rationale.
+- Real canary artifacts with sensitive details:
+  - repository names
+  - branch names
+  - CI internals/logs
+  - cost/latency breakdowns
+  - operational identifiers
+- Enterprise roadmap details not ready for public commitments.
+
+## Repo Hygiene Rules
+
+1. Commit code + tests.
+2. Do not commit raw run artifacts by default.
+3. Publish sanitized summaries/templates only.
+4. Keep full evidence bundles in private storage.
+
+## Executable Guardrail
+
+Use the classifier before publishing:
+
+```bash
+agentmesh classify --staged --fail-on-private --fail-on-review
+```
+
+- Exit `2`: private files present.
+- Exit `3`: review-required files present.
+
+Use full release preflight for automation:
+
+```bash
+agentmesh release-check --staged --require-witness --json
+```
+
+In CI, you can roll this out in two phases:
+
+- **Phase 1 (preview/non-blocking):** collect release-check artifacts.
+- **Phase 2 (blocking):** fail PRs on release-check non-zero exit.
+
+## Recommended Workflow
+
+1. Run canary and store full artifacts privately.
+2. Generate a sanitized public summary from those artifacts.
+3. Publish public notes describing capabilities and outcomes, not sensitive internals.
+
+## Why This Split Exists
+
+- **Public layer** proves technical capability and accelerates adoption.
+- **Private layer** retains monetizable operational intelligence and enterprise differentiation.
+
+## Monetization Alignment
+
+- OSS remains the distribution channel (install growth, trust, ecosystem integrations).
+- Paid value should concentrate on:
+  - managed evidence operations and reporting
+  - enterprise policy packs and compliance controls
+  - historical analytics/replay and SLA-backed insights
+  - private implementation playbooks and support workflows

--- a/docs/public-private-decision-matrix.md
+++ b/docs/public-private-decision-matrix.md
@@ -1,0 +1,78 @@
+# Public vs Private Decision Matrix
+
+Use this matrix when deciding whether content belongs in the OSS repo.
+
+## Step 1: Classify Automatically
+
+Run:
+
+```bash
+agentmesh classify --staged --json
+```
+
+- `private`: keep internal unless fully sanitized.
+- `review`: manual decision required.
+- `public`: generally safe to publish.
+
+## Step 2: Apply Commercial Lens
+
+If uncertain, use this rule:
+
+- Publish what proves **capability**.
+- Keep private what encodes **advantage**.
+
+### Publish (Capability Signal)
+
+- Product behavior, APIs, tests, reliability fixes.
+- Generic architecture and operator runbooks.
+- Open benchmarks and sanitized implementation summaries.
+
+### Keep Private (Advantage Signal)
+
+- GTM/pricing/packaging strategy.
+- Customer-specific controls and internal roadmap sequencing.
+- Raw canary evidence (internal repos, CI internals, cost/latency traces).
+- Internal playbooks that materially improve win-rate or margins.
+
+## Step 3: Redaction Checklist (for any review/private artifact)
+
+1. Remove internal repo names and branch identifiers.
+2. Remove CI internals and tokenized URLs.
+3. Remove raw cost/latency traces unless intentionally public.
+4. Replace absolute local paths with generic placeholders.
+5. Re-run `agentmesh classify` after edits.
+
+## Release Gate (recommended)
+
+Before merge/publish:
+
+```bash
+agentmesh classify --staged --fail-on-private --fail-on-review
+```
+
+If this fails, either sanitize or move the artifact to private storage.
+
+For deterministic release automation (classification + weave + optional witness/tests):
+
+```bash
+agentmesh release-check --staged --require-witness --json
+```
+
+To publish alpha gate evidence safely:
+
+```bash
+agentmesh sanitize-alpha-gate-report \
+  --in .agentmesh/runs/alpha-gate-report.json \
+  --out docs/alpha-gate-report.public.json
+```
+
+## CI Rollout Pattern
+
+1. Start with PR preview mode (non-blocking) and collect artifacts.
+2. Triage common review/private hits and tune policy globs.
+3. Flip to blocking once false positives are under control.
+
+Current repo setup follows this pattern:
+
+- `public-private-guard` blocks private artifacts on PRs.
+- `release-check-preview` runs in non-blocking mode and uploads `.release-check.json`.


### PR DESCRIPTION
## Summary

Documentation and templates for the alpha gate system. No runtime or workflow changes.

- **Operator runbook**: `docs/alpha-gate-runbook.md`
- **Public/private boundary**: `docs/public-private-boundary.md`
- **Decision matrix**: `docs/public-private-decision-matrix.md`
- **Report templates**: `docs/alpha-gate-report.md`, `docs/alpha-gate-report.template.json`
- **PR template**: `.github/pull_request_template.md`
- **AGENTS.md**: updated with alpha gate context
- **README.md**: added Documentation Policy section

## Depends On

- PR #3 (alpha gate core runtime) -- **merged**

## Gate Check

- Zero `src/` changes
- Zero `.github/workflows/` changes
- 263 tests passing (unchanged from PR A)

## Test Plan

- [x] `pytest tests/ -q` -- 263 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)