### PR TITLE
Alpha gate: CI knobs and release scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,98 @@ on:
     branches: [main]
 
 jobs:
+  public-private-guard:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Block private artifacts in PR diff
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          CHANGED="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          if [ -z "$CHANGED" ]; then
+            echo "No changed files."
+            exit 0
+          fi
+          echo "Changed files:"
+          echo "$CHANGED"
+          git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" | xargs -0 agentmesh classify --fail-on-private
+
+  release-check-preview:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run release-check preview on PR diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          base = os.environ["BASE_SHA"]
+          head = os.environ["HEAD_SHA"]
+          changed = subprocess.run(
+              ["git", "diff", "--name-only", base, head],
+              capture_output=True,
+              text=True,
+              check=True,
+          ).stdout.splitlines()
+
+          out_path = Path(".release-check.json")
+          if not changed:
+              payload = {"release_check": {"ok": True, "exit_code": 0, "skipped": "no_changed_files"}}
+              out_path.write_text(json.dumps(payload, indent=2) + "\n")
+              print(out_path.read_text())
+              sys.exit(0)
+
+          cmd = ["agentmesh", "release-check", "--json", *changed]
+          print("Running:", " ".join(cmd))
+          proc = subprocess.run(cmd, capture_output=True, text=True)
+          stdout = proc.stdout.strip()
+          stderr = proc.stderr.strip()
+          if stdout:
+              print(stdout)
+          if stderr:
+              print(stderr, file=sys.stderr)
+          out_path.write_text((stdout or "{}") + "\n")
+          sys.exit(proc.returncode)
+          PY
+
+      - name: Upload release-check preview artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-check-preview
+          path: .release-check.json
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/scripts/alpha_gate_report.py
+++ b/scripts/alpha_gate_report.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Generate a machine-readable Alpha Gate report for an orchestrated run."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agentmesh.alpha_gate import write_alpha_gate_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", required=True, help="AgentMesh data dir used by the run")
+    parser.add_argument(
+        "--out",
+        default=".agentmesh/runs/alpha-gate-report.json",
+        help="Output report path (raw artifacts should stay private)",
+    )
+    parser.add_argument("--ci-log", default="", help="Optional CI log file path to scan for VERIFIED")
+    parser.add_argument(
+        "--ci-result-json",
+        default="",
+        help="Optional structured CI result JSON (preferred over --ci-log)",
+    )
+    parser.add_argument(
+        "--witness-optional",
+        action="store_true",
+        help="Do not fail gate if CI witness status is unavailable",
+    )
+    args = parser.parse_args()
+
+    ci_log_text = ""
+    if args.ci_log:
+        ci_path = Path(args.ci_log)
+        if ci_path.exists():
+            ci_log_text = ci_path.read_text()
+    ci_result = None
+    if args.ci_result_json:
+        ci_json_path = Path(args.ci_result_json)
+        if ci_json_path.exists():
+            import json
+            parsed = json.loads(ci_json_path.read_text())
+            if isinstance(parsed, dict):
+                ci_result = parsed
+
+    report = write_alpha_gate_report(
+        out_path=Path(args.out),
+        data_dir=Path(args.data_dir),
+        ci_log_text=ci_log_text,
+        ci_result=ci_result,
+        require_witness_verified=not args.witness_optional,
+    )
+    print(f"wrote {args.out}  overall_pass={report['overall_pass']}")
+    return 0 if report["overall_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sanitize_alpha_gate_report.py
+++ b/scripts/sanitize_alpha_gate_report.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Sanitize an alpha gate report for public publication."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agentmesh.alpha_gate import write_sanitized_alpha_gate_report  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--in",
+        dest="in_path",
+        default=".agentmesh/runs/alpha-gate-report.json",
+        help="Raw/private alpha gate report JSON",
+    )
+    parser.add_argument(
+        "--out",
+        dest="out_path",
+        default="docs/alpha-gate-report.public.json",
+        help="Sanitized/public alpha gate report JSON",
+    )
+    args = parser.parse_args()
+
+    in_path = Path(args.in_path)
+    out_path = Path(args.out_path)
+    if not in_path.exists():
+        print(f"input not found: {in_path}", file=sys.stderr)
+        return 1
+
+    report = write_sanitized_alpha_gate_report(in_path, out_path)
+    print(f"wrote {out_path}  overall_pass={report.get('overall_pass', False)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

CI workflow additions and release scripts for the alpha gate system.

- **public-private-guard** (CI job): blocks PRs containing private/canary artifacts in the diff
- **release-check-preview** (CI job): non-blocking release preflight with `release-check-preview` JSON artifact (90-day retention)
- **scripts/alpha_gate_report.py**: machine-readable alpha gate report generator
- **scripts/sanitize_alpha_gate_report.py**: sanitizer for public publication of gate artifacts

## Depends On

- PR #3 (alpha gate core runtime) -- **merged**
- PR #4 (alpha gate docs) -- **merged**

## Gate Check

- Zero `src/` changes
- Zero `docs/` changes
- Workflow YAML structurally validated
- release-check-preview uses `continue-on-error: true` (non-blocking)
- 263 tests passing (unchanged)

## Test Plan

- [x] `pytest tests/ -q` -- 263 passed
- [x] YAML structural validation
- [ ] CI green
- [ ] Verify release-check-preview artifact appears on a subsequent PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)