### PR TITLE
feat: anti-omission weave sequence continuity + gap detection

### DIFF
--- a/src/agentmesh/cli.py
+++ b/src/agentmesh/cli.py
@@ -1611,6 +1611,12 @@ def weave_verify() -> None:
     if valid:
         console.print("[green]Weave chain valid[/green]")
     else:
+        events.append_event(
+            EventKind.WEAVE_CHAIN_BREAK,
+            agent_id=_auto_agent_id(),
+            payload={"error": err},
+            data_dir=_get_data_dir(),
+        )
         console.print(f"[red]Weave chain BROKEN[/red]: {err}")
         raise typer.Exit(1)
 
@@ -2011,6 +2017,7 @@ def orch_watch(
         EventKind.ORCH_ABORT_ALL.value,
         EventKind.ORCH_LEASE_RENEW.value,
         EventKind.ADAPTER_LOAD.value,
+        EventKind.WEAVE_CHAIN_BREAK.value,
     }
 
     since = 0

--- a/src/agentmesh/models.py
+++ b/src/agentmesh/models.py
@@ -89,6 +89,7 @@ class EventKind(str, enum.Enum):
     COST_EXCEEDED = "COST_EXCEEDED"
     TEST_MISMATCH = "TEST_MISMATCH"
     ASSAY_RECEIPT = "ASSAY_RECEIPT"
+    WEAVE_CHAIN_BREAK = "WEAVE_CHAIN_BREAK"
 
 
 def _now() -> str:
@@ -166,6 +167,7 @@ class Episode(BaseModel, frozen=True):
 
 class WeaveEvent(BaseModel, frozen=True):
     event_id: str
+    sequence_id: int = 0
     episode_id: str = ""
     prev_hash: str = ""
     capsule_id: str = ""

--- a/tests/test_weaver.py
+++ b/tests/test_weaver.py
@@ -1,12 +1,20 @@
-"""Tests for provenance weaver -- 6 scenarios."""
+"""Tests for provenance weaver."""
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+from typer.testing import CliRunner
+
 from agentmesh import db
+from agentmesh import events
+from agentmesh.cli import app
+from agentmesh.models import EventKind
 from agentmesh.weaver import append_weave, verify_weave, trace_file, export_weave_md
 from agentmesh.episodes import start_episode
+
+runner = CliRunner()
 
 
 def test_append_weave(tmp_data_dir: Path) -> None:
@@ -72,3 +80,67 @@ def test_export_md(tmp_data_dir: Path) -> None:
     assert ep_id in md
     assert "abc123" in md
     assert "src/main.py:run" in md
+
+
+def test_weave_sequence_ids_monotonic(tmp_data_dir: Path) -> None:
+    append_weave(capsule_id="c1", data_dir=tmp_data_dir)
+    append_weave(capsule_id="c2", data_dir=tmp_data_dir)
+    append_weave(capsule_id="c3", data_dir=tmp_data_dir)
+    evts = db.list_weave_events(tmp_data_dir)
+    assert [e.sequence_id for e in evts] == [1, 2, 3]
+
+
+def test_verify_detects_sequence_gap(tmp_data_dir: Path) -> None:
+    append_weave(capsule_id="c1", data_dir=tmp_data_dir)
+    append_weave(capsule_id="c2", data_dir=tmp_data_dir)
+    append_weave(capsule_id="c3", data_dir=tmp_data_dir)
+    evts = db.list_weave_events(tmp_data_dir)
+    conn = db.get_connection(tmp_data_dir)
+    try:
+        conn.execute(
+            "UPDATE weave_events SET sequence_id = 7 WHERE event_id = ?",
+            (evts[1].event_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    valid, err = verify_weave(tmp_data_dir)
+    assert not valid
+    assert "Sequence gap at" in err
+
+
+def test_cli_weave_verify_emits_chain_break_event(tmp_data_dir: Path, monkeypatch) -> None:
+    append_weave(capsule_id="c1", data_dir=tmp_data_dir)
+    append_weave(capsule_id="c2", data_dir=tmp_data_dir)
+    evts = db.list_weave_events(tmp_data_dir)
+    conn = db.get_connection(tmp_data_dir)
+    try:
+        conn.execute(
+            "UPDATE weave_events SET sequence_id = 5 WHERE event_id = ?",
+            (evts[1].event_id,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
+    monkeypatch.setenv("AGENTMESH_AGENT_ID", "test_agent")
+    result = runner.invoke(app, ["weave", "verify"])
+    assert result.exit_code == 1
+    all_events = events.read_events(tmp_data_dir)
+    chain_break = [e for e in all_events if e.kind == EventKind.WEAVE_CHAIN_BREAK]
+    assert len(chain_break) == 1
+    assert "Sequence gap" in chain_break[0].payload["error"]
+
+
+def test_concurrent_append_assigns_unique_monotonic_sequences(tmp_data_dir: Path) -> None:
+    def _append(i: int) -> int:
+        evt = append_weave(capsule_id=f"c{i}", data_dir=tmp_data_dir)
+        return evt.sequence_id
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        seqs = list(pool.map(_append, range(30)))
+
+    assert sorted(seqs) == list(range(1, 31))
+    valid, err = verify_weave(tmp_data_dir)
+    assert valid, err


### PR DESCRIPTION
## Summary
- add `sequence_id` to weave events with idempotent DB migration and deterministic backfill
- enforce sequence continuity in `verify_weave` (fail closed on gaps)
- emit `WEAVE_CHAIN_BREAK` event from CLI `weave verify` on verification failure
- order weave reads by sequence across DB/query/export paths
- harden concurrent append with retry on sequence collisions
- add race/regression tests for sequence monotonicity and gap detection

## Validation
- `uv run pytest tests/test_weaver.py tests/test_commit.py tests/test_passport.py tests/test_release_check.py -q` (36 passed)
- `uv run pytest tests/ -q` (289 passed)

## Notes
- passport import currently preserves imported `prev_hash` while reassigning local `sequence_id`; cross-ledger splice semantics are intentionally deferred.
