### PR TITLE
ci: enforce weave integrity check with tamper-detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           import subprocess
@@ -128,6 +128,72 @@ jobs:
         with:
           name: assay-gate-report
           path: .assay/
+
+  weave-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Verify weave tamper detection
+        env:
+          AGENTMESH_DATA_DIR: ${{ github.workspace }}/.agentmesh-ci
+          AGENTMESH_AGENT_ID: ci_weave_guard
+        run: |
+          set -euo pipefail
+
+          agentmesh weave record --trace-id ci.weave.1 | tee -a weave-verify.log
+          agentmesh weave record --trace-id ci.weave.2 | tee -a weave-verify.log
+          agentmesh weave verify | tee -a weave-verify.log
+
+          python - <<'PY'
+          import os
+          import sqlite3
+          from pathlib import Path
+
+          db_path = Path(os.environ["AGENTMESH_DATA_DIR"]) / "board.db"
+          conn = sqlite3.connect(str(db_path))
+          try:
+              row = conn.execute(
+                  "SELECT event_id FROM weave_events ORDER BY created_at DESC LIMIT 1"
+              ).fetchone()
+              if row is None:
+                  raise SystemExit("no weave events to tamper")
+              conn.execute(
+                  "UPDATE weave_events SET event_hash = ? WHERE event_id = ?",
+                  ("sha256:deadbeef", row[0]),
+              )
+              conn.commit()
+          finally:
+              conn.close()
+          PY
+
+          set +e
+          agentmesh weave verify >> weave-verify.log 2>&1
+          verify_status=$?
+          set -e
+
+          if [ "$verify_status" -eq 0 ]; then
+            echo "Expected weave verify to fail after tamper, got success." | tee -a weave-verify.log
+            exit 1
+          fi
+          echo "Tamper detection verified (non-zero exit: $verify_status)." | tee -a weave-verify.log
+
+      - name: Upload weave integrity artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weave-integrity
+          path: |
+            weave-verify.log
+            .agentmesh-ci/events.jsonl
+            .agentmesh-ci/board.db
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a dedicated `weave-integrity` job to CI
- exercise an end-to-end integrity flow in CI: record weave events, verify passes, tamper DB, verify fails (expected)
- upload `weave-verify.log` and weave DB artifacts on every run for audit/debug

## Why
Anti-omission controls only matter if they are exercised automatically. This job makes weave integrity verification an always-on CI control.

## Validation
- local dry-run of workflow commands (record -> verify -> tamper -> verify fail)
- `uv run pytest tests/test_release_check.py -q` (6 passed)
