### PR TITLE
test: proof-carrying canary with weave integrity gate

### DIFF
--- a/src/agentmesh/alpha_gate.py
+++ b/src/agentmesh/alpha_gate.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from . import db, events
+from . import db, events, weaver
 from .models import EventKind, TaskState
 
 
@@ -124,6 +124,7 @@ def build_alpha_gate_report(
     transition_cov = _task_transition_coverage(tasks, data_dir)
     watchdog_ok = _watchdog_handled(rows)
     spawn_loss = _spawn_loss_check(data_dir)
+    weave_ok, weave_err = weaver.verify_weave(data_dir=data_dir)
 
     witness_from_result = _witness_verified_from_result(ci_result)
     if witness_from_result is None:
@@ -139,6 +140,7 @@ def build_alpha_gate_report(
             "required": require_witness_verified,
             "source": witness_source,
         },
+        "weave_chain_intact": {"pass": weave_ok, "error": weave_err},
         "full_transition_receipts": transition_cov,
         "watchdog_handled_event": {"pass": watchdog_ok},
         "no_orphan_finalization_loss": spawn_loss,


### PR DESCRIPTION
## Summary
- add `weave_chain_intact` check to Alpha Gate reports using `weaver.verify_weave`
- include verification error detail in report when weave integrity fails
- add regression test that proves Alpha Gate fails when weave hash chain is corrupted

## Why
This makes anti-omission controls first-class in the gate report itself: not just transition receipts, but cryptographic chain integrity too.

## Validation
- `uv run pytest tests/test_alpha_gate.py tests/test_weaver.py tests/test_assay_bridge.py -q` (29 passed)
- `uv run pytest tests/ -q` (290 passed)
- local orchestrated canary run (isolated data dir) produced full-pass private report:
  - merged task count: pass
  - witness verified CI: pass (witness optional mode for local run)
  - weave chain intact: pass
  - full transition receipts: pass
  - watchdog handled event: pass
  - no orphan/finalization loss: pass

## Notes
- Raw canary artifacts were kept private under `.agentmesh/runs/` and are not included in this PR.
