### PR TITLE
ci: require assay-verify in KPI and add verify job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,40 @@ jobs:
           name: assay-gate-report
           path: .assay/
 
+  assay-verify:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install assay
+        run: pip install "assay-ai>=1.10.1"
+
+      - name: Build and verify proof pack
+        run: |
+          set -euo pipefail
+          mkdir -p .assay-verify
+
+          assay run \
+            --allow-empty \
+            --output ".assay-verify/proof_pack_ci" \
+            --json \
+            -- python -c "print('agentmesh assay verify canary')" \
+            | tee ".assay-verify/run.json"
+
+          assay verify-pack ".assay-verify/proof_pack_ci" --json | tee ".assay-verify/verify.json"
+
+      - name: Upload verify artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: assay-verify-report
+          path: .assay-verify/
+
   weave-integrity:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/evidence-kpi.yml
+++ b/.github/workflows/evidence-kpi.yml
@@ -45,6 +45,9 @@ jobs:
             --repo "${{ github.repository }}" \
             --base "$BASE" \
             --days "$DAYS" \
+            --required-check lineage \
+            --required-check assay-gate \
+            --required-check assay-verify \
             --out-json "kpi/evidence-chain-kpi.json" \
             --out-md "kpi/evidence-chain-kpi.md"
 

--- a/src/agentmesh/evidence_kpi.py
+++ b/src/agentmesh/evidence_kpi.py
@@ -13,7 +13,7 @@ from typing import Any
 
 
 GITHUB_API = "https://api.github.com"
-DEFAULT_REQUIRED_CHECKS = ("lineage", "assay-gate")
+DEFAULT_REQUIRED_CHECKS = ("lineage", "assay-gate", "assay-verify")
 
 
 def parse_iso8601(value: str) -> datetime:
@@ -286,7 +286,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         dest="required_check",
         default=[],
-        help="required check run name (repeatable). Defaults: lineage + assay-gate",
+        help="required check run name (repeatable). Defaults: lineage + assay-gate + assay-verify",
     )
     parser.add_argument("--max-prs", type=int, default=200, help="max PRs to inspect")
     parser.add_argument("--token-env", default="GITHUB_TOKEN", help="env var holding GitHub token")

--- a/tests/test_evidence_kpi.py
+++ b/tests/test_evidence_kpi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from agentmesh.evidence_kpi import (
+    DEFAULT_REQUIRED_CHECKS,
     compute_coverage,
     evaluate_required_checks,
     select_latest_check_runs,
@@ -12,6 +13,7 @@ def test_select_latest_check_runs_prefers_highest_id() -> None:
         {"id": 101, "name": "lineage", "status": "completed", "conclusion": "failure"},
         {"id": 102, "name": "lineage", "status": "completed", "conclusion": "success"},
         {"id": 201, "name": "assay-gate", "status": "completed", "conclusion": "success"},
+        {"id": 301, "name": "assay-verify", "status": "completed", "conclusion": "success"},
     ]
     latest = select_latest_check_runs(runs)
     assert latest["lineage"]["id"] == 102
@@ -22,12 +24,13 @@ def test_evaluate_required_checks_complete_success() -> None:
     latest = {
         "lineage": {"id": 1, "status": "completed", "conclusion": "success"},
         "assay-gate": {"id": 2, "status": "completed", "conclusion": "success"},
+        "assay-verify": {"id": 3, "status": "completed", "conclusion": "success"},
     }
     complete, statuses, missing, failed = evaluate_required_checks(
-        latest, ["lineage", "assay-gate"]
+        latest, ["lineage", "assay-gate", "assay-verify"]
     )
     assert complete is True
-    assert statuses == {"lineage": "success", "assay-gate": "success"}
+    assert statuses == {"lineage": "success", "assay-gate": "success", "assay-verify": "success"}
     assert missing == []
     assert failed == []
 
@@ -35,17 +38,23 @@ def test_evaluate_required_checks_complete_success() -> None:
 def test_evaluate_required_checks_missing_and_failed() -> None:
     latest = {
         "lineage": {"id": 1, "status": "completed", "conclusion": "failure"},
+        "assay-gate": {"id": 2, "status": "completed", "conclusion": "success"},
     }
     complete, statuses, missing, failed = evaluate_required_checks(
-        latest, ["lineage", "assay-gate"]
+        latest, ["lineage", "assay-gate", "assay-verify"]
     )
     assert complete is False
     assert statuses["lineage"] == "failure"
-    assert statuses["assay-gate"] == "missing"
-    assert missing == ["assay-gate"]
+    assert statuses["assay-gate"] == "success"
+    assert statuses["assay-verify"] == "missing"
+    assert missing == ["assay-verify"]
     assert failed == ["lineage"]
 
 
 def test_compute_coverage_handles_zero_total() -> None:
     assert compute_coverage(0, 0) == 0.0
     assert compute_coverage(3, 4) == 75.0
+
+
+def test_default_required_checks_include_assay_verify() -> None:
+    assert DEFAULT_REQUIRED_CHECKS == ("lineage", "assay-gate", "assay-verify")


### PR DESCRIPTION
## Summary
- add a new PR CI job `assay-verify` that builds a proof pack and runs `assay verify-pack`
- upload `.assay-verify` artifacts for audit/debug
- include `assay-verify` in evidence KPI defaults
- pin KPI workflow required checks to: lineage, assay-gate, assay-verify
- update KPI unit tests for 3-check completeness logic

## Validation
- `pytest tests/test_evidence_kpi.py -q`
- `pytest tests/ -q`
- workflow_dispatch run on branch (`days=30`) confirms `required_checks` includes `assay-verify`
