### PR TITLE
feat: add enforcement-aware evidence KPI monitoring

### DIFF
--- a/.github/workflows/evidence-enforcement-monitor.yml
+++ b/.github/workflows/evidence-enforcement-monitor.yml
@@ -1,0 +1,243 @@
+name: Evidence Enforcement Monitor
+
+on:
+  schedule:
+    - cron: "29 5 * * *"
+  workflow_dispatch:
+    inputs:
+      enforcement_date:
+        description: "Enforcement start date (YYYY-MM-DD)"
+        required: false
+        default: "2026-02-24"
+      base:
+        description: "Base branch"
+        required: false
+        default: "main"
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  issues: write
+
+jobs:
+  enforcement-monitor:
+    runs-on: ubuntu-latest
+    env:
+      DEFAULT_ENFORCEMENT_DATE: "2026-02-24"
+      ISSUE_TITLE: "[Governance] Evidence chain coverage below 100% since enforcement"
+      ISSUE_LABEL: "evidence-enforcement"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Compute enforcement KPI
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ENFORCEMENT_DATE="${{ github.event.inputs.enforcement_date }}"
+          BASE="${{ github.event.inputs.base }}"
+          if [ -z "$ENFORCEMENT_DATE" ]; then ENFORCEMENT_DATE="$DEFAULT_ENFORCEMENT_DATE"; fi
+          if [ -z "$BASE" ]; then BASE="main"; fi
+
+          python scripts/evidence_kpi.py \
+            --repo "${{ github.repository }}" \
+            --base "$BASE" \
+            --days 30 \
+            --slice-days 7 \
+            --slice-days 30 \
+            --enforcement-date "$ENFORCEMENT_DATE" \
+            --required-check lineage \
+            --required-check assay-gate \
+            --required-check assay-verify \
+            --out-json "kpi/evidence-enforcement-kpi.json" \
+            --out-md "kpi/evidence-enforcement-kpi.md"
+
+      - name: Evaluate enforcement coverage
+        id: eval
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report_path = Path("kpi/evidence-enforcement-kpi.json")
+          report = json.loads(report_path.read_text())
+          since = report.get("since_enforcement") or {}
+
+          total = int(since.get("ai_prs_total", 0))
+          passing = int(since.get("passing_prs", 0))
+          coverage = float(since.get("coverage_pct", 0.0))
+          enforcement_date = report.get("enforcement_date", "")
+          breach = total > 0 and coverage < 100.0
+
+          summary = (
+              f"since_enforcement={passing}/{total} ({coverage}%), "
+              f"enforcement_date={enforcement_date or 'unset'}, "
+              f"breach={'true' if breach else 'false'}"
+          )
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as fh:
+              fh.write(f"breach={'true' if breach else 'false'}\n")
+              fh.write(f"coverage_pct={coverage}\n")
+              fh.write(f"passing={passing}\n")
+              fh.write(f"total={total}\n")
+              fh.write(f"enforcement_date={enforcement_date}\n")
+              fh.write(f"summary={summary}\n")
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary_path:
+              with open(summary_path, "a", encoding="utf-8") as fh:
+                  fh.write("## Enforcement Monitor\n\n")
+                  fh.write(f"- {summary}\n")
+          print(summary)
+          PY
+
+      - name: Upload KPI artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-enforcement-kpi
+          path: kpi/
+
+      - name: Ensure drift label exists
+        if: steps.eval.outputs.breach == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const name = process.env.ISSUE_LABEL;
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name });
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name,
+                color: "B60205",
+                description: "Evidence-chain enforcement coverage dropped below policy threshold",
+              });
+            }
+
+      - name: Open or update enforcement drift issue
+        if: steps.eval.outputs.breach == 'true'
+        uses: actions/github-script@v7
+        env:
+          COVERAGE_PCT: ${{ steps.eval.outputs.coverage_pct }}
+          PASSING: ${{ steps.eval.outputs.passing }}
+          TOTAL: ${{ steps.eval.outputs.total }}
+          ENFORCEMENT_DATE: ${{ steps.eval.outputs.enforcement_date }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const title = process.env.ISSUE_TITLE;
+            const label = process.env.ISSUE_LABEL;
+            const coverage = process.env.COVERAGE_PCT;
+            const passing = process.env.PASSING;
+            const total = process.env.TOTAL;
+            const enforcementDate = process.env.ENFORCEMENT_DATE || "unset";
+            const runUrl = process.env.RUN_URL;
+
+            const body = [
+              "Evidence-chain governance drift detected.",
+              "",
+              `- since_enforcement coverage: **${passing}/${total} (${coverage}%)**`,
+              `- enforcement date: \`${enforcementDate}\``,
+              `- workflow run: ${runUrl}`,
+              "",
+              "Required checks: `lineage`, `assay-gate`, `assay-verify`",
+              "",
+              "This issue auto-updates while drift persists."
+            ].join("\n");
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: label,
+              per_page: 100,
+            });
+
+            const existing = openIssues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body: `Drift persists: ${passing}/${total} (${coverage}%) in ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }
+
+      - name: Close enforcement drift issue on recovery
+        if: steps.eval.outputs.breach != 'true'
+        uses: actions/github-script@v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COVERAGE_PCT: ${{ steps.eval.outputs.coverage_pct }}
+          PASSING: ${{ steps.eval.outputs.passing }}
+          TOTAL: ${{ steps.eval.outputs.total }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const title = process.env.ISSUE_TITLE;
+            const label = process.env.ISSUE_LABEL;
+            const runUrl = process.env.RUN_URL;
+            const passing = process.env.PASSING;
+            const total = process.env.TOTAL;
+            const coverage = process.env.COVERAGE_PCT;
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: label,
+              per_page: 100,
+            });
+            const existing = openIssues.find((issue) => issue.title === title);
+            if (!existing) return;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: existing.number,
+              body: `Recovered to ${passing}/${total} (${coverage}%) in ${runUrl}. Closing.`,
+            });
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: existing.number,
+              state: "closed",
+            });
+
+      - name: Fail on enforcement drift
+        if: steps.eval.outputs.breach == 'true'
+        env:
+          PASSING: ${{ steps.eval.outputs.passing }}
+          TOTAL: ${{ steps.eval.outputs.total }}
+          COVERAGE_PCT: ${{ steps.eval.outputs.coverage_pct }}
+        run: |
+          echo "::error::Evidence-chain coverage dropped below 100% since enforcement (${PASSING}/${TOTAL}, ${COVERAGE_PCT}%)."
+          exit 1

--- a/.github/workflows/evidence-kpi.yml
+++ b/.github/workflows/evidence-kpi.yml
@@ -8,11 +8,15 @@ on:
       days:
         description: "Lookback window in days"
         required: false
-        default: "7"
+        default: "30"
       base:
         description: "Base branch"
         required: false
         default: "main"
+      enforcement_date:
+        description: "Enforcement start date (YYYY-MM-DD)"
+        required: false
+        default: "2026-02-24"
 
 permissions:
   contents: read
@@ -22,6 +26,8 @@ permissions:
 jobs:
   evidence-kpi:
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_ENFORCEMENT_DATE: "2026-02-24"
     steps:
       - uses: actions/checkout@v4
 
@@ -38,13 +44,18 @@ jobs:
         run: |
           DAYS="${{ github.event.inputs.days }}"
           BASE="${{ github.event.inputs.base }}"
-          if [ -z "$DAYS" ]; then DAYS="7"; fi
+          ENFORCEMENT_DATE="${{ github.event.inputs.enforcement_date }}"
+          if [ -z "$DAYS" ]; then DAYS="30"; fi
           if [ -z "$BASE" ]; then BASE="main"; fi
+          if [ -z "$ENFORCEMENT_DATE" ]; then ENFORCEMENT_DATE="$DEFAULT_ENFORCEMENT_DATE"; fi
 
           python scripts/evidence_kpi.py \
             --repo "${{ github.repository }}" \
             --base "$BASE" \
             --days "$DAYS" \
+            --slice-days 7 \
+            --slice-days 30 \
+            --enforcement-date "$ENFORCEMENT_DATE" \
             --required-check lineage \
             --required-check assay-gate \
             --required-check assay-verify \

--- a/tests/test_evidence_kpi.py
+++ b/tests/test_evidence_kpi.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from datetime import timezone
+
 from agentmesh.evidence_kpi import (
     DEFAULT_REQUIRED_CHECKS,
     compute_coverage,
     evaluate_required_checks,
+    normalize_window_days,
+    parse_date_or_datetime_utc,
     select_latest_check_runs,
 )
 
@@ -58,3 +62,18 @@ def test_compute_coverage_handles_zero_total() -> None:
 
 def test_default_required_checks_include_assay_verify() -> None:
     assert DEFAULT_REQUIRED_CHECKS == ("lineage", "assay-gate", "assay-verify")
+
+
+def test_normalize_window_days_includes_primary_and_defaults() -> None:
+    windows = normalize_window_days(30, [14, 30], include_default_slices=True)
+    assert windows == [7, 14, 30]
+
+
+def test_parse_date_or_datetime_utc_accepts_date_and_iso() -> None:
+    dt_date = parse_date_or_datetime_utc("2026-02-24")
+    assert dt_date.tzinfo == timezone.utc
+    assert dt_date.isoformat() == "2026-02-24T00:00:00+00:00"
+
+    dt_iso = parse_date_or_datetime_utc("2026-02-24T12:34:56Z")
+    assert dt_iso.tzinfo == timezone.utc
+    assert dt_iso.isoformat() == "2026-02-24T12:34:56+00:00"


### PR DESCRIPTION
## Summary
- extend `src/agentmesh/evidence_kpi.py` with enforcement-date-aware evaluation and 7d/30d slice reporting
- update `.github/workflows/evidence-kpi.yml` defaults/inputs to run 30-day windows with optional enforcement date and slice windows
- add nightly `.github/workflows/evidence-enforcement-monitor.yml` workflow that opens/updates/closes a drift issue and fails on breach
- add parser/normalization tests for date handling and slice configuration

## Validation
- `.venv/bin/python -m pytest tests/test_evidence_kpi.py -q`
- `PATH="$PWD/.tmp-bin:$PATH" .venv/bin/python -m pytest tests/ -q` (299 passed)
