### PR TITLE
ci: align enforcement baseline to 2026-02-25

### DIFF
--- a/.github/workflows/evidence-enforcement-monitor.yml
+++ b/.github/workflows/evidence-enforcement-monitor.yml
@@ -8,7 +8,7 @@ on:
       enforcement_date:
         description: "Enforcement start date (YYYY-MM-DD)"
         required: false
-        default: "2026-02-24"
+        default: "2026-02-25"
       base:
         description: "Base branch"
         required: false
@@ -24,7 +24,7 @@ jobs:
   enforcement-monitor:
     runs-on: ubuntu-latest
     env:
-      DEFAULT_ENFORCEMENT_DATE: "2026-02-24"
+      DEFAULT_ENFORCEMENT_DATE: "2026-02-25"
       ISSUE_TITLE: "[Governance] Evidence chain coverage below 100% since enforcement"
       ISSUE_LABEL: "evidence-enforcement"
     steps:

--- a/.github/workflows/evidence-kpi.yml
+++ b/.github/workflows/evidence-kpi.yml
@@ -16,7 +16,7 @@ on:
       enforcement_date:
         description: "Enforcement start date (YYYY-MM-DD)"
         required: false
-        default: "2026-02-24"
+        default: "2026-02-25"
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ jobs:
   evidence-kpi:
     runs-on: ubuntu-latest
     env:
-      DEFAULT_ENFORCEMENT_DATE: "2026-02-24"
+      DEFAULT_ENFORCEMENT_DATE: "2026-02-25"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- move default enforcement baseline date from `2026-02-24` to `2026-02-25` in KPI workflows
- align monitor/evidence windows to the date when all required checks were live (`lineage`, `assay-gate`, `assay-verify`)
- no logic changes beyond baseline constants

## Why
PRs merged before full required-check rollout should not count against post-enforcement coverage. This makes since-enforcement KPI reflect the real governance start.

## Validation
- `.venv/bin/python -m pytest tests/test_evidence_kpi.py -q` (7 passed)
