### PR TITLE
ci: use timestamped enforcement baseline

### DIFF
--- a/.github/workflows/evidence-enforcement-monitor.yml
+++ b/.github/workflows/evidence-enforcement-monitor.yml
@@ -6,9 +6,9 @@ on:
   workflow_dispatch:
     inputs:
       enforcement_date:
-        description: "Enforcement start date (YYYY-MM-DD)"
+        description: "Enforcement start (YYYY-MM-DD or ISO8601)"
         required: false
-        default: "2026-02-25"
+        default: "2026-02-25T04:40:16Z"
       base:
         description: "Base branch"
         required: false
@@ -24,7 +24,7 @@ jobs:
   enforcement-monitor:
     runs-on: ubuntu-latest
     env:
-      DEFAULT_ENFORCEMENT_DATE: "2026-02-25"
+      DEFAULT_ENFORCEMENT_DATE: "2026-02-25T04:40:16Z"
       ISSUE_TITLE: "[Governance] Evidence chain coverage below 100% since enforcement"
       ISSUE_LABEL: "evidence-enforcement"
     steps:

--- a/.github/workflows/evidence-kpi.yml
+++ b/.github/workflows/evidence-kpi.yml
@@ -14,9 +14,9 @@ on:
         required: false
         default: "main"
       enforcement_date:
-        description: "Enforcement start date (YYYY-MM-DD)"
+        description: "Enforcement start (YYYY-MM-DD or ISO8601)"
         required: false
-        default: "2026-02-25"
+        default: "2026-02-25T04:40:16Z"
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ jobs:
   evidence-kpi:
     runs-on: ubuntu-latest
     env:
-      DEFAULT_ENFORCEMENT_DATE: "2026-02-25"
+      DEFAULT_ENFORCEMENT_DATE: "2026-02-25T04:40:16Z"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- switch enforcement baseline defaults from date-only to timestamped ISO8601 (`2026-02-25T04:40:16Z`)
- update both KPI workflows to accept/communicate ISO8601 enforcement inputs

## Why
Date-only baseline includes early 2026-02-25 PRs that predate full required-check rollout. Timestamp baseline aligns enforcement math to the first fully governed PR window.

## Validation
- `.venv/bin/python -m pytest tests/test_evidence_kpi.py -q` (7 passed)
