### PR TITLE
fix: preserve full ISO enforcement timestamp in KPI output

### DIFF
--- a/src/agentmesh/evidence_kpi.py
+++ b/src/agentmesh/evidence_kpi.py
@@ -327,7 +327,7 @@ def run(args: argparse.Namespace) -> int:
     enforcement_dt: datetime | None = None
     if args.enforcement_date:
         enforcement_dt = parse_date_or_datetime_utc(args.enforcement_date)
-        enforcement_date = enforcement_dt.date().isoformat()
+        enforcement_date = enforcement_dt.isoformat().replace("+00:00", "Z")
         if enforcement_dt < fetch_since:
             fetch_since = enforcement_dt
 


### PR DESCRIPTION
## Summary
- preserve full ISO8601 enforcement timestamp in KPI report output instead of truncating to date-only
- keep filtering behavior unchanged (already timestamp-precise); this aligns report payload with actual enforcement boundary semantics

## Why
Audit artifacts should reflect the exact boundary used by KPI computation. Previously, an input like `2026-02-25T04:40:16Z` was displayed as `2026-02-25`, which lost precision.

## Validation
- `.venv/bin/python -m pytest tests/test_evidence_kpi.py -q` (7 passed)
- `PATH="$PWD/.tmp-bin:$PATH" .venv/bin/python -m pytest tests/ -q` (299 passed)
