### PR TITLE
feat: persist KPI trend history in workflow artifacts

### DIFF
--- a/.github/workflows/evidence-kpi.yml
+++ b/.github/workflows/evidence-kpi.yml
@@ -19,6 +19,7 @@ on:
         default: "2026-02-25T04:40:16Z"
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
   checks: read
@@ -62,6 +63,152 @@ jobs:
             --out-json "kpi/evidence-chain-kpi.json" \
             --out-md "kpi/evidence-chain-kpi.md"
 
+      - name: Find previous successful KPI run
+        id: find_prev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import urllib.parse
+          import urllib.request
+
+          token = os.environ["GITHUB_TOKEN"]
+          repo = os.environ["GITHUB_REPOSITORY"]
+          current_run_id = int(os.environ["GITHUB_RUN_ID"])
+          owner, name = repo.split("/", 1)
+          query = urllib.parse.urlencode(
+              {
+                  "branch": "main",
+                  "status": "success",
+                  "per_page": 30,
+              }
+          )
+          url = (
+              f"https://api.github.com/repos/{owner}/{name}/actions/workflows/"
+              f"evidence-kpi.yml/runs?{query}"
+          )
+          req = urllib.request.Request(
+              url=url,
+              headers={
+                  "Authorization": f"Bearer {token}",
+                  "Accept": "application/vnd.github+json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+                  "User-Agent": "agentmesh-evidence-kpi-history/1",
+              },
+              method="GET",
+          )
+
+          previous_run_id = ""
+          try:
+              with urllib.request.urlopen(req, timeout=30) as resp:
+                  payload = json.loads(resp.read().decode("utf-8"))
+              for run in payload.get("workflow_runs", []):
+                  rid = int(run.get("id") or 0)
+                  if rid and rid != current_run_id:
+                      previous_run_id = str(rid)
+                      break
+          except Exception:
+              previous_run_id = ""
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"previous_run_id={previous_run_id}\n")
+          print(f"previous_run_id={previous_run_id or 'none'}")
+          PY
+
+      - name: Download previous KPI trend artifact
+        if: steps.find_prev.outputs.previous_run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: evidence-chain-kpi-history
+          path: .kpi-history
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.find_prev.outputs.previous_run_id }}
+
+      - name: Update KPI trend history
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_WORKFLOW_NAME: ${{ github.workflow }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          from agentmesh.evidence_kpi import build_trend_point, merge_trend_history
+
+          report_path = Path("kpi/evidence-chain-kpi.json")
+          report = json.loads(report_path.read_text())
+
+          history_file = None
+          history_root = Path(".kpi-history")
+          if history_root.exists():
+              candidates = list(history_root.rglob("evidence-chain-kpi-history.jsonl"))
+              if candidates:
+                  history_file = candidates[0]
+
+          existing = []
+          if history_file and history_file.exists():
+              for line in history_file.read_text().splitlines():
+                  raw = line.strip()
+                  if not raw:
+                      continue
+                  try:
+                      item = json.loads(raw)
+                  except json.JSONDecodeError:
+                      continue
+                  if isinstance(item, dict):
+                      existing.append(item)
+
+          point = build_trend_point(
+              report,
+              run_id=os.environ.get("GITHUB_RUN_ID", ""),
+              run_attempt=os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+              run_url=os.environ.get("GITHUB_RUN_URL", ""),
+              workflow=os.environ.get("GITHUB_WORKFLOW_NAME", ""),
+              event_name=os.environ.get("GITHUB_EVENT_NAME", ""),
+              ref_name=os.environ.get("GITHUB_REF_NAME", ""),
+          )
+          merged = merge_trend_history(existing, point, max_points=365)
+
+          out_jsonl = Path("kpi/evidence-chain-kpi-history.jsonl")
+          out_jsonl.parent.mkdir(parents=True, exist_ok=True)
+          out_jsonl.write_text(
+              "".join(json.dumps(item, sort_keys=True) + "\n" for item in merged)
+          )
+
+          lines = [
+              "# Evidence KPI Trend (Last 14 Runs)",
+              "",
+              "| Generated | Primary | Since enforcement | Run |",
+              "|---|---:|---:|---|",
+          ]
+          for item in reversed(merged[-14:]):
+              generated = str(item.get("generated_at", ""))[:19] + "Z"
+              primary = f"{item.get('passing_prs', 0)}/{item.get('ai_prs_total', 0)} ({item.get('coverage_pct', 0.0)}%)"
+              since = (
+                  f"{item.get('since_enforcement_passing_prs', 0)}/"
+                  f"{item.get('since_enforcement_ai_prs_total', 0)} "
+                  f"({item.get('since_enforcement_coverage_pct', 0.0)}%)"
+              )
+              run_url = str(item.get("run_url", ""))
+              run_id = str(item.get("run_id", ""))
+              run_link = f"[{run_id}]({run_url})" if run_id and run_url else run_id
+              lines.append(f"| {generated} | {primary} | {since} | {run_link} |")
+
+          Path("kpi/evidence-chain-kpi-history.md").write_text("\n".join(lines) + "\n")
+          print(f"trend_points={len(merged)}")
+          PY
+
       - name: Add summary
         if: always()
         run: |
@@ -70,6 +217,10 @@ jobs:
           else
             echo "No KPI markdown produced." >> "$GITHUB_STEP_SUMMARY"
           fi
+          if [ -f kpi/evidence-chain-kpi-history.md ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat kpi/evidence-chain-kpi-history.md >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload KPI artifact
         if: always()
@@ -77,3 +228,12 @@ jobs:
         with:
           name: evidence-chain-kpi
           path: kpi/
+
+      - name: Upload KPI trend artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: evidence-chain-kpi-history
+          path: |
+            kpi/evidence-chain-kpi-history.jsonl
+            kpi/evidence-chain-kpi-history.md


### PR DESCRIPTION
## Summary
- persist a rolling KPI trend history (`evidence-chain-kpi-history.jsonl`) entirely in workflow artifacts
- fetch previous successful KPI run artifact, append current point, dedupe by `run_id`, and cap history length to 365 points
- publish trend markdown (`evidence-chain-kpi-history.md`) to step summary + artifact
- add per-run metadata (`run_id`, `run_url`, workflow/event/ref) to each trend point
- add helper functions + unit tests for trend point construction and history merge behavior

## Why
This gives directional KPI signal over time without creating nightly commits on `main`.

## Validation
- `.venv/bin/python -m pytest tests/test_evidence_kpi.py -q` (11 passed)
- `PATH="$PWD/.tmp-bin:$PATH" .venv/bin/python -m pytest tests/ -q` (303 passed)
