### PR TITLE
fix: enforce terminal advance side-effects for merged and aborted

### DIFF
--- a/src/agentmesh/cli.py
+++ b/src/agentmesh/cli.py
@@ -1766,7 +1766,7 @@ def orch_depends(
 @orch_app.command(name="advance")
 def orch_advance(
     task_id: str = typer.Argument(..., help="Task ID"),
-    to: str = typer.Option(..., "--to", help="Target state (running, pr_open, ci_pass, review_pass, merged)"),
+    to: str = typer.Option(..., "--to", help="Target state (running, pr_open, ci_pass, review_pass, merged, aborted)"),
     reason: str = typer.Option("", "--reason", "-r", help="Reason for transition"),
     pr_url: str = typer.Option("", "--pr-url", help="PR URL (for pr_open transition)"),
     json_out: bool = typer.Option(False, "--json", help="JSON output"),
@@ -1785,7 +1785,7 @@ def orch_advance(
         kwargs["pr_url"] = pr_url
     with _orchestrator_lease(json_out=json_out):
         try:
-            task = orchestrator.transition_task(task_id, to_state, reason=reason, data_dir=_get_data_dir(), **kwargs)
+            task = orchestrator.advance_task(task_id, to_state, reason=reason, data_dir=_get_data_dir(), **kwargs)
         except orchestrator.TransitionError as e:
             if json_out:
                 console.print(json.dumps({"error": str(e)}, indent=2))

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -128,6 +128,9 @@ def test_abort_from_running(data_dir, agent):
 
     task = orchestrator.abort_task(task.task_id, reason="timeout", data_dir=data_dir)
     assert task.state == TaskState.ABORTED
+    attempts = db.list_attempts(task.task_id, data_dir)
+    assert attempts[-1].outcome == "failure"
+    assert attempts[-1].ended_at != ""
 
 
 def test_abort_from_planned(data_dir):


### PR DESCRIPTION
## Summary
- add orchestrator `advance_task(...)` so terminal transitions run deterministic side-effects instead of raw state transition only
- make `orch advance` call `advance_task`
- finalize latest open attempt on terminal transitions (`success` on merged, `failure` on aborted)
- keep terminal bridge emission deterministic via `ASSAY_RECEIPT` on both `MERGED` and `ABORTED`
- add CLI regression tests for merged/aborted terminal advances

## Regression coverage
- `advance(..., to=merged)` closes the open attempt
- `ASSAY_RECEIPT` emitted on merged terminal advance
- `ASSAY_RECEIPT` emitted on aborted terminal advance

## Validation
- `pytest tests/test_orchestrator.py tests/test_orch_cli.py tests/test_assay_bridge.py -q`
- `pytest tests/ -q`
