### PR TITLE
feat(assay): add lockfile and harden CI evidence gate

### DIFF
--- a/.assay.yaml
+++ b/.assay.yaml
@@ -1,0 +1,10 @@
+version: "1"
+project: agentmesh
+scan:
+  include:
+    - "src/**/*.py"
+  exclude:
+    - "**/test_*.py"
+ci:
+  min_score: 0
+  require_lock: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Run evidence gate
         run: |
           mkdir -p .assay
-          assay gate check . --min-score 0 --json | tee .assay/gate-check.json
+          assay gate check . --min-score 0 --require-lock --json | tee .assay/gate-check.json
 
       - name: Upload gate report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ ci-witness.log
 tmp_alpha_gate_data/
 .agentmesh/runs/
 docs/alpha-gate-report.json
+
+# Assay evidence artifacts (transient)
+.assay/
+.assay-verify/
+proof_pack_*/

--- a/assay.lock
+++ b/assay.lock
@@ -1,0 +1,26 @@
+{
+  "lock_version": "1.0",
+  "assay_version_min": "1.11.1",
+  "pack_format_version": "0.1.0",
+  "receipt_schema_version": "3.0",
+  "run_cards": [
+    {
+      "id": "receipt_completeness",
+      "name": "Receipt Completeness",
+      "claim_set_hash": "0b9affe4a6e67d069cb3413aaf982fc05110dae0af8a0b4dce180e63e5d564dc"
+    }
+  ],
+  "run_cards_composite_hash": "df2e18533a1433cf2a21645d00862cced6355b62da7d969c7e9a377e65b26663",
+  "claim_set_hash": "0b9affe4a6e67d069cb3413aaf982fc05110dae0af8a0b4dce180e63e5d564dc",
+  "exit_contract": {
+    "0": "integrity_pass AND claims_pass",
+    "1": "integrity_pass AND claims_fail",
+    "2": "integrity_fail"
+  },
+  "signer_policy": {
+    "mode": "any",
+    "allowed_fingerprints": []
+  },
+  "locked_at": "2026-03-01T05:07:18.369441+00:00",
+  "locked_by_assay_version": "1.11.1"
+}


### PR DESCRIPTION
## Summary

- Ports Episode D pilot hardening (ccio PR #8) to canonical agentmesh
- Initializes `assay.lock` lockfile for instrumentation fingerprinting (+15 points)
- Adds `.assay.yaml` project config with `require_lock: true`
- Hardens CI gate with `--require-lock` flag
- No source instrumentation changes — agentmesh has 0 detected model call sites

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| Findings | 0 | 0 |
| Instrumented | 0/0 | 0/0 |
| Score | ~41.5 | **56.5** |
| Lockfile | missing | **present + valid** |
| CI gate | partial | partial + require-lock |

## Files changed

- `assay.lock` — lockfile with instrumentation fingerprint (must be committed)
- `.assay.yaml` — scan config (`src/**/*.py`, require_lock: true)
- `.github/workflows/ci.yml` — add `--require-lock` to gate check
- `.gitignore` — exclude `.assay/`, `.assay-verify/`, `proof_pack_*/`

## Risk

- **CI**: Advisory-only (`--min-score 0`) — cannot block merge
- **Lockfile staleness**: `assay lock update` fixes; CI warns but doesn't block

## Test plan

- [ ] Verify `assay score . --json` shows score ≥ 55
- [ ] Verify `assay.lock` is valid: `assay lock verify`
- [ ] Verify existing CI checks pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)