### PR TITLE
fix(pilot): use @main ref for reusable workflow

### DIFF
--- a/.github/workflows/assay-pilot.yml
+++ b/.github/workflows/assay-pilot.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   pilot:
-    uses: Haserjian/ccio/.github/workflows/assay-pilot.yml@ef548c04d66316761bc25d61c18d01fd407558ed
+    uses: Haserjian/ccio/.github/workflows/assay-pilot.yml@main
     with:
       test_cmd: ${{ inputs.test_cmd || 'python -c print(0)' }}
       mode: ${{ inputs.mode || 'high-only' }}


### PR DESCRIPTION
## Summary

Switch reusable workflow ref from SHA pin to `@main`. The SHA ref failed with HTTP 422 because GitHub Actions couldn't resolve the cross-repo private workflow at a commit SHA (even with `access_level: user` set on ccio).

Once this is confirmed working, we can pin to a tag release instead.

## Test plan

- [x] CI will validate
- [ ] `workflow_dispatch` trigger after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)