### PR TITLE
docs: add CLAUDE.md and copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,61 @@
+# Copilot Instructions for AgentMesh
+
+## Codebase overview
+
+- **Language**: Python 3.10+
+- **Type hints**: Required (pydantic models throughout)
+- **Testing**: pytest; 38 test modules under `tests/`
+- **Style**: Black formatter, isort
+- **Dependencies**: pydantic>=2.0, typer>=0.9, rich>=13.0
+- **Optional**: cryptography (witness signing), mcp (Model Context Protocol)
+
+## Core patterns
+
+### Episodes and claims
+
+Every work session is an **episode**. Before editing a file, **claim** it. This prevents multi-agent conflicts.
+
+```bash
+# CLI equivalent
+agentmesh episode start --title "my task"
+agentmesh claim src/agentmesh/cli.py
+# ... work ...
+agentmesh episode end
+
+# Or use the happy-path wrapper:
+agentmesh task start --title "my task" --claim src/agentmesh/cli.py
+agentmesh task finish --message "feat: done"
+```
+
+### Provenance (weaver)
+
+The weaver maintains a hash chain linking every change to its predecessor. Do not break the chain — always go through the weaver API.
+
+### Witness signing
+
+Optional Ed25519 signing via `src/agentmesh/witness.py`. When enabled, commits include cryptographic attestation in trailers.
+
+### Public/private classification
+
+All staged files are classified before merge. Private artifacts (credentials, internal configs) are blocked by CI.
+
+```bash
+agentmesh classify --staged --fail-on-private
+```
+
+## Code standards
+
+- **Imports**: stdlib, third-party, local
+- **Models**: Use pydantic BaseModel for all data structures
+- **CLI**: Use typer for new commands; match existing patterns in `cli.py`
+- **Commits**: conventional format `type(scope): description`
+- **Commit trailers**: Include `AgentMesh-Episode: <id>` when working in an episode
+
+## When to flag for human review
+
+- Changes to `witness.py` or signing logic
+- Changes to `public_private.py` classification rules
+- New CLI commands or breaking changes to existing ones
+- Changes to `weaver.py` hash chain logic
+- CI/CD workflow modifications
+- Schema changes to episode/claim/capsule models

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# AgentMesh Project Guide
+
+Local-first multi-agent coordination and provenance system for coding workflows. Adds deterministic coordination, commit-linked lineage, and portable handoff bundles on top of git.
+
+## Key paths
+
+| Area | Path | Purpose |
+|------|------|---------|
+| CLI | `src/agentmesh/cli.py` | Main entry point (`agentmesh` command) |
+| Database | `src/agentmesh/db.py` | Episode/claim/state persistence |
+| Orchestrator | `src/agentmesh/orchestrator.py` | Multi-agent task coordination |
+| Spawner | `src/agentmesh/spawner.py` | Agent spawn and lifecycle |
+| Weaver | `src/agentmesh/weaver.py` | Hash-chained provenance |
+| Witness | `src/agentmesh/witness.py` | Ed25519 cryptographic signing |
+| Claims | `src/agentmesh/claims.py` | File/resource locking |
+| Capsules | `src/agentmesh/capsules.py` | SBAR context bundles for handoffs |
+| Public/private | `src/agentmesh/public_private.py` | Classification layer |
+| Assay bridge | `src/agentmesh/assay_bridge.py` | Receipt standard integration |
+| Alpha gate | `src/agentmesh/alpha_gate.py` | Release gating |
+| Evidence KPI | `src/agentmesh/evidence_kpi.py` | KPI tracking |
+| Playbook | `AGENTS.md` | Coordination playbook |
+
+## Core concepts
+
+- **Episodes**: Unique work session IDs binding claims, capsules, and commits
+- **Claims**: File/port locks acquired before editing (prevents conflicts)
+- **Capsules**: SBAR context bundles for agent-to-agent handoffs
+- **Weaver**: Hash-chained provenance linking every change to its history
+- **Witness**: Optional Ed25519 signing of commits and provenance
+- **Commit trailers**: `AgentMesh-Episode: <id>` + optional witness signatures
+
+## Commands
+
+```bash
+# Core workflow
+agentmesh episode start --title "my task"   # Start an episode
+agentmesh claim <file>                      # Lock a file
+agentmesh bundle emit                       # Create handoff capsule
+agentmesh episode end                       # Close episode
+
+# Happy-path wrapper (start + claim + finish in fewer steps)
+agentmesh task start --title "my task" --claim src/foo.py
+agentmesh task finish --message "feat: done"
+
+# Classification
+agentmesh classify --staged --fail-on-private
+agentmesh release-check --staged --json
+
+# Tests
+python3 -m pytest tests/ -q
+```
+
+## Conventions
+
+- **Commits**: conventional format `type(scope): description`
+- **Public/private boundary**: `agentmesh classify` gates CI — private artifacts must not leak
+- **Auth**: gh CLI keyring (do NOT set GITHUB_TOKEN env var)
+
+## CI workflows
+
+| Workflow | What it does |
+|----------|--------------|
+| `ci.yml` | Public-private guard + release-check preview |
+| `assay-pilot.yml` | Assay evidence gate |
+| `branch-protection-drift.yml` | Detect protection rule drift |
+| `evidence-enforcement-monitor.yml` | Monitor evidence enforcement |
+| `evidence-kpi.yml` | Track evidence KPIs |
+| `dco.yml` | Developer Certificate of Origin |
+| `lineage.yml` | Provenance lineage check |
+| `publish.yml` | PyPI publication gate |


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Project guide for AI assistants — key paths, core concepts (episodes, claims, capsules, weaver, witness), commands, conventions, CI workflows
- **.github/copilot-instructions.md**: Coding standards (Python 3.10+, pydantic, typer), episode/claim patterns, provenance chain rules, public/private classification, human review triggers

## Test plan
- [ ] Docs-only — no code changes
- [ ] Verify CLAUDE.md loads correctly in Claude Code sessions on this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)