### PR TITLE
docs: proof-carrying PR canary touchpoint

### DIFF
--- a/docs/CANARY_TOUCHPOINT.md
+++ b/docs/CANARY_TOUCHPOINT.md
@@ -1,0 +1,4 @@
+# Canary Touchpoint
+
+This file exists to trigger the proof-carrying PR canary.
+It tests the evidence chain, not the product surface.


### PR DESCRIPTION
Trivial docs addition to trigger the proof-carrying PR canary.

This PR tests the evidence chain, not the product surface.
The diff is intentionally boring.

**Evidence to verify after CI:**
- Episode trailers present on commit
- Witness signature verified
- Weave chain integrity passes
- Lineage check passes
- Assay gate check runs
- Public/private classification passes

Episode: `ep_019d07b7bc9ffb92db2381b1`