### PR TITLE
chore: coherence pass — bump assay-ai pin to 1.22.0 + OpenClaw discoverability

### DIFF
--- a/.github/workflows/assay-pilot.yml
+++ b/.github/workflows/assay-pilot.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyyaml "assay-ai==1.18.0"
+          python -m pip install pyyaml "assay-ai==1.22.0"
 
       - name: Verify assay is available
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install assay
-        run: pip install "assay-ai==1.18.0"
+        run: pip install "assay-ai==1.22.0"
 
       - name: Save baseline on first run
         run: |
@@ -191,7 +191,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install assay
-        run: pip install "assay-ai==1.18.0"
+        run: pip install "assay-ai==1.22.0"
 
       - name: Import signer and bootstrap trust overlay
         env:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ AgentMesh integrates with [Assay](https://github.com/Haserjian/assay) to produce
 - **Alpha Gate**: release gating with 6 checks (merged task count, witness verification, weave chain integrity, full transition receipts, watchdog handling, no orphan loss).
 - **Evidence KPI**: nightly workflow tracking evidence pipeline health — pass rates, enforcement dates, trend history.
 - **Evidence Wire Protocol v0**: canonical `_ewp_*` identity envelope for cross-repo evidence flow.
+- **OpenClaw integration (via Assay)**: Assay ships a bounded OpenClaw integration — a subprocess-membrane adapter with receipt emission, allowlist enforcement, and signed proof-pack verification. Try it with `assay try-openclaw`. See the [OpenClaw support doc](https://github.com/Haserjian/assay/blob/main/docs/openclaw-support.md).
 
 Every PR to `main` must pass lineage + assay-gate + assay-verify + weave-integrity checks.
 


### PR DESCRIPTION
## Why now

`assay-ai 1.22.0` is already shipped and live on PyPI, but this repo's CI pinned `assay-ai==1.18.0` (two minor versions behind), and the README made no mention of the OpenClaw integration that Assay now ships. This is the `agentmesh`-side of a bounded four-repo coherence pass aligning the public surface with already-shipped reality.

## Scope (only public coherence edits in this repo)

1. **CI pin bump.** `.github/workflows/ci.yml` (two instances) and `.github/workflows/assay-pilot.yml` (one instance): `assay-ai==1.18.0` → `assay-ai==1.22.0`.

2. **OpenClaw discoverability.** One new bullet in the Evidence Pipeline section of `README.md` surfacing that Assay ships a bounded OpenClaw integration (subprocess-membrane adapter with receipt emission, allowlist enforcement, and signed proof-pack verification). Links to the OpenClaw support doc in the `assay` repo and names `assay try-openclaw` as the entry point.

Total diff: 3 files, +4 -3.

## Smoke test (local)

Exercised the three `assay-gate` CI commands against `assay-ai==1.22.0` in a fresh Python 3.12 venv over this worktree before opening the PR:

- `assay lock check assay.lock --json` → exit 0, `status: ok`, no issues
- `assay gate save-baseline . --json` → exit 0, score 62.5, baseline file created
- `assay gate check . --min-score 0 --json` → exit 0, result `PASS`

All green locally. The `assay-verify` job commands (verify-pack, trust bootstrap) need signer keys and run in PR context — not exercised in local smoke.

## Not included

- No behavior changes in AgentMesh itself
- No new feature claims
- No branch cleanup
- No `src/` or test changes
- Uncommitted working-tree edits on main (AGENTS.md, README.md, uv.lock) are explicitly out of scope — this branch is based on `origin/main`, not on the dirty tree

## Sibling PRs

This PR is part of a coordinated four-repo coherence pass:

- Haserjian/assay#67 — bounded receipt line, pilot waitlist, VendorQ demote
- Haserjian/agentmesh#41 — this PR: `assay-ai` pin bump to `1.22.0` + OpenClaw discoverability
- Haserjian/assay-scorecard#1 — bump scan-version reference to `v1.22.0`
- Haserjian/assay-verify-action#12 — OpenClaw integration link in Links section