### PR TITLE
docs: add Threadwork naming foundation and surface inventory

### DIFF
--- a/docs/naming/THREADWORK_RENAME_MEMO.md
+++ b/docs/naming/THREADWORK_RENAME_MEMO.md
@@ -1,0 +1,90 @@
+# Threadwork Rename Memo
+
+Status: proposed migration memo for `AgentMesh` -> `Threadwork`.
+
+## Decision
+
+`Threadwork` is the canonical public name for the coordination and provenance
+substrate.
+
+`AgentMesh` is deprecated as a public name and remains a compatibility alias
+during the migration window.
+
+## Scope
+
+This memo covers public naming migration only.
+
+It does not rename code immediately. It defines how to move safely from
+`AgentMesh` to `Threadwork` without a flag day.
+
+Policy:
+- `Threadwork` is the canonical public name.
+- `AgentMesh` remains a compatibility alias during migration.
+- No flag-day rename.
+- No proof-layer rename.
+- `Assay` keeps receipts, proof packs, reviewer packets, and verdicts.
+- Existing implementation names may persist temporarily where rename risk is
+  high.
+
+## Compatibility Matrix
+
+| Surface | Migration policy now | End-state target | Notes |
+|---|---|---|---|
+| README/docs narrative | Rename now | `Threadwork` | First public surface to change |
+| CLI command names | Alias later | `threadwork` canonical, `agentmesh` accepted during window | Avoid breaking existing scripts |
+| Config keys | Alias later | `threadwork.*` or neutral keys where justified | Keep old keys readable during window |
+| Schema enum/string values | Preserve initially | Review case-by-case | High risk for compatibility and receipts |
+| Trailers / receipts | Alias later | New emission may move to `Threadwork-*`; old `AgentMesh-*` must remain parseable | History must stay readable |
+| State paths such as `.agentmesh` | Preserve initially | Review later | High migration risk; do not break local state |
+| GitHub action / repo naming | Rename narrative first, implementation later | `threadwork` naming where practical | Keep existing references working until coordinated cut |
+| Python package/module paths | Preserve initially | Review later | Highest-risk implementation surface |
+
+## Migration Phases
+
+### Phase 1: naming freeze
+
+- Freeze ontology and public naming
+- Publish terms and migration memo
+- Stop debating umbrella vocabulary
+
+### Phase 2: docs and narrative
+
+- Update README and docs to prefer `Threadwork`
+- Add “formerly AgentMesh” language where needed
+- Keep proof-layer language under `Assay`
+
+### Phase 3: compatibility aliases
+
+- Add `Threadwork` as canonical public term
+- Keep `agentmesh` CLI/config/trailer/state compatibility
+- Do not remove old readers during this phase
+
+### Phase 4: implementation review
+
+- Inventory public `AgentMesh` surfaces
+- Classify each as rename now, alias later, preserve internal, or risky
+- Rename only low-risk surfaces with explicit receipts
+
+### Phase 5: deprecation and removal
+
+- Stop emitting deprecated names first
+- Continue reading old names for a longer window
+- Remove old names only after compatibility evidence is clear
+
+## Non-Goals
+
+- No immediate invasive rename of internals
+- No rename of `Assay` receipts, proof packs, reviewer packets, or verdicts
+- No forced rename of every internal `mesh` term
+- No migration of `.agentmesh` or other state paths until explicitly reviewed
+- No accidental staging of `.loom/` or `data/`
+
+## Review Checklist
+
+- Does the change make `Threadwork` the canonical public name?
+- Does it preserve `AgentMesh` as a compatibility alias where breakage risk is
+  high?
+- Does it avoid renaming the proof layer?
+- Does it avoid touching state paths unless explicitly planned?
+- Does it keep old trailers, schemas, and receipts readable?
+- Does it stage only intended docs and not runtime artifacts?

--- a/docs/naming/THREADWORK_SURFACE_INVENTORY.md
+++ b/docs/naming/THREADWORK_SURFACE_INVENTORY.md
@@ -1,0 +1,80 @@
+# Threadwork Surface Inventory
+
+Status: inventory-only pass for `AgentMesh` -> `Threadwork`.
+
+Purpose: list public or compatibility-sensitive `AgentMesh` surfaces without
+renaming them yet.
+
+## Classification Legend
+
+- `rename now`: low-risk public narrative surface; update in docs/name-first phase
+- `alias later`: public surface that should gain a `Threadwork` alias before old
+  naming is removed
+- `preserve internal`: internal or historical surface that can keep old naming
+  for now
+- `risky/needs review`: high-breakage or contract-sensitive surface; do not
+  rename casually
+
+## Inventory
+
+| Surface | Current value | Classification | Evidence | Notes |
+|---|---|---|---|---|
+| Repo/product narrative | `AgentMesh` | `rename now` | `README.md:1`, `README.md:3`, `README.md:11` | Primary public narrative should move first |
+| Cross-repo public docs narrative | `AgentMesh` in Assay docs | `rename now` | `../assay-toolkit/docs/BOUNDARY_MAP.md:9`, `../assay-toolkit/docs/REPO_MAP.md:16`, `../assay-toolkit/docs/security/SECURITY_POSTURE_TODAY.md:96` | Public-facing stack language should converge on `Threadwork` |
+| Internal strategy narrative | `AgentMesh` in active strategy docs | `rename now` | `../assay-internal/strategy/STRATEGY_STACK_HIERARCHY.md:13`, `../assay-internal/strategy/COMMERCIAL_DOCTRINE_CANON.md:82` | Rename where these are current doctrine, not historical records |
+| CLI command | `agentmesh` | `alias later` | `pyproject.toml:43`, `src/agentmesh/cli.py:23` | `threadwork` should become canonical, `agentmesh` should keep working during migration |
+| Secondary CLI entrypoint | `agentmesh-mcp` | `alias later` | `pyproject.toml:44` | Public executable surface; should not disappear without a compatibility window |
+| Package install name | `agentmesh-core` | `alias later` | `pyproject.toml:6`, `README.md:5`, `README.md:26` | Public package surface; needs coordination before change |
+| Package metadata URLs and badges | GitHub repo/action URLs, PyPI badge | `risky/needs review` | `pyproject.toml:37-40`, `README.md:5` | Depends on repo slug and package naming; update only when target locations are fixed |
+| Python package/module path | `src/agentmesh`, `import agentmesh` | `risky/needs review` | `pyproject.toml:59` | High-risk import path; defer until compatibility plan is explicit |
+| GitHub repo slug | `Haserjian/agentmesh` | `risky/needs review` | `../assay-toolkit/docs/REPO_MAP.md:16`, `../assay-toolkit/docs/REPO_MAP.md:65` | Repo rename ripples into docs, links, and action references |
+| GitHub Action name and refs | `agentmesh-action`, `Haserjian/agentmesh-action@v2` | `alias later` | `README.md:91`, `README.md:106`, `pyproject.toml:40` | Narrative can move first; action refs need a compatibility window |
+| Workflow display names and action refs in CI | `AgentMesh lineage coverage`, `Haserjian/agentmesh-action@v1` | `alias later` | `.github/workflows/lineage.yml:15-16` | User-visible CI naming can shift, but action refs are compatibility-sensitive |
+| MCP server name | `agentmesh` | `alias later` | `src/agentmesh/mcp_server.py:14` | Integration surface; avoid silent breaking changes |
+| CLI metadata/tool id | `tool_name: "agentmesh"` | `alias later` | `src/agentmesh/cli.py:311` | Public-ish integration string; should transition with aliasing |
+| Hook marker and hook script names | `agentmesh`, `agentmesh_pre_edit.sh`, `agentmesh_post_edit.sh` | `preserve internal` | `src/agentmesh/hooks/install.py:18`, `src/agentmesh/hooks/install.py:14` | Internal plumbing; low value to rename early |
+| Commit trailer keys | `AgentMesh-Episode`, `AgentMesh-KeyID`, `AgentMesh-Witness`, `AgentMesh-Sig`, related chunk keys | `alias later` | `src/agentmesh/cli.py:27`, `src/agentmesh/witness.py:17-23`, `docs/spec/cwe-v1.md:85-93` | New emission can change later, but old history must remain parseable |
+| Receipt/provenance export type strings | `agentmesh_weave`, `agentmesh_witness` | `risky/needs review` | `src/agentmesh/provenance_export.py:38`, `src/agentmesh/provenance_export.py:88` | Downstream consumers may rely on these exact strings |
+| Assay bridge/source organ strings | `source_organ: "agentmesh"` | `risky/needs review` | `src/agentmesh/assay_bridge.py:68` | Contract boundary; rename only with explicit receipt compatibility policy |
+| Assay schema enum/string values | `"agentmesh"` | `risky/needs review` | `../assay-toolkit/src/assay/decision_receipt.py:65`, `../assay-toolkit/src/assay/schemas/decision_receipt_v0.2.0.schema.json:308`, `../assay-toolkit/src/assay/schemas/claim_assertion.v0.1.schema.json:112` | Public contract surface; may require dual-acceptance for a long window |
+| State dir in home | `~/.agentmesh` | `risky/needs review` | `src/agentmesh/keystore.py:17`, `src/agentmesh/events.py:14`, `src/agentmesh/db.py:19` | Do not break local state; likely needs dual-read before any migration |
+| Repo-local state dir | `.agentmesh/` | `risky/needs review` | `src/agentmesh/cli.py:96`, `src/agentmesh/public_private.py:81`, `src/agentmesh/worker_adapters.py:254` | Same issue as home dir plus repo policy/config coupling |
+| Config file path and prompts | `.agentmesh/policy.json` and related help text | `alias later` | `src/agentmesh/cli.py:241`, `src/agentmesh/cli.py:675`, `src/agentmesh/spawner.py:125` | User-facing path strings can be dual-documented before any storage migration |
+| Session path | `~/.agentmesh/.session_id` | `preserve internal` | `src/agentmesh/cli.py:55` | Internal runtime detail; low-value early rename |
+| Portable bundle extension | `.meshpack` | `risky/needs review` | `src/agentmesh/passport.py:1`, `src/agentmesh/cli.py:1108`, `README.md:11` | File format surface; no reason to rename until broader compatibility story exists |
+| Documentation/spec references for trailers and bundle format | `AgentMesh-*`, `.meshpack` | `alias later` | `docs/spec/cwe-v1.md:85-113`, `docs/pilot/failure-modes.md:11-16` | Specs must reflect old readers and future aliases honestly |
+| Public docs/examples with hardcoded repo/action links | `github.com/Haserjian/agentmesh`, `agentmesh-action`, `agentmesh` commands | `rename now` | `docs/pilot/outreach.md:16`, `docs/pilot/outreach.md:68-72`, `.github/copilot-instructions.md:1`, `.github/copilot-instructions.md:20-27` | Narrative/examples should match canonical naming once docs-first rename starts |
+| Historical/security docs referencing AgentMesh as past state | `AgentMesh` in audits/adjudications | `preserve internal` | `../assay-toolkit/docs/security/SECURITY_AUDIT_ADJUDICATION_2026-04-03.md:31` | Historical records should not be rewritten casually |
+
+## Recommended Cut Order
+
+1. `rename now`
+   - README/docs narrative in this repo
+   - active public docs in `assay-toolkit`
+   - active strategy/doctrine docs in `assay-internal`
+
+2. `alias later`
+   - CLI command
+   - GitHub Action naming
+   - MCP/tool identifiers
+   - trailer emission and docs
+   - config path/help text
+
+3. `risky/needs review`
+   - package/module paths
+   - schema enums and receipt strings
+   - state dirs and config storage paths
+   - `.meshpack` file format
+   - repo slug
+
+4. `preserve internal`
+   - hook marker/script names
+   - session/runtime details
+   - historical records that describe old reality accurately
+
+## Notes
+
+- This inventory is intentionally narrow: it covers public or compatibility-
+  sensitive surfaces, not every internal `agentmesh` string in tests.
+- `.loom/` and `data/` were intentionally not staged or modified.
+- The next safe rename slice is still docs-first, not code-first.

--- a/docs/naming/THREADWORK_SURFACE_INVENTORY.md
+++ b/docs/naming/THREADWORK_SURFACE_INVENTORY.md
@@ -5,6 +5,12 @@ Status: inventory-only pass for `AgentMesh` -> `Threadwork`.
 Purpose: list public or compatibility-sensitive `AgentMesh` surfaces without
 renaming them yet.
 
+Baseline: line-number references in the Evidence column below were captured
+against `handoff/m2-switch-2026-04-11` (agentmesh) and the then-current state
+of `assay-toolkit` / `assay-internal`. When read against `main` or any branch
+without the M2 handoff docs, specific line numbers may drift by a handful of
+lines; file paths, surface names, and classifications remain valid.
+
 ## Classification Legend
 
 - `rename now`: low-risk public narrative surface; update in docs/name-first phase

--- a/docs/naming/THREADWORK_TERMS.md
+++ b/docs/naming/THREADWORK_TERMS.md
@@ -1,0 +1,152 @@
+# Threadwork Terms
+
+Status: proposed naming freeze for migration planning.
+
+This document locks the ontology before any broad rename. It defines the
+intended boundary between `Threadwork`, `AgentMesh`, `Assay`, and
+`threadstone` so the rename does not sprawl into a vague `Thread*` suite.
+
+## Decision
+
+Canonical public coordination-substrate name: `Threadwork`
+
+Deprecated public name: `AgentMesh`
+
+Current migration posture:
+- No flag-day rename
+- No immediate implementation-wide rewrite
+- `AgentMesh` remains a compatibility alias during the migration window
+
+## Core Terms
+
+### Threadwork
+
+`Threadwork` is the governed coordination and provenance substrate for
+delegated work.
+
+It owns:
+- coordination of delegated work
+- continuity across handoffs
+- execution provenance
+- live work structure around claims, episodes, and capsules
+
+It does not own:
+- proof-pack verification
+- trust verdicts
+- reviewer-facing settlement artifacts
+
+### thread
+
+A `thread` is the live unit of coordinated delegated work.
+
+It may span:
+- one or more episodes
+- multiple claims
+- multiple commits
+- multiple handoffs
+
+Use `thread` for the running work object, not for the durable promoted
+artifact.
+
+### threadlog
+
+A `threadlog` is the chronological execution/provenance log for a thread.
+
+Use this term for:
+- ordered events
+- handoff history
+- provenance trails
+- continuity records
+
+Do not use it as a synonym for a proof pack or a verdict.
+
+### threadflow
+
+`threadflow` is optional vocabulary for the handoff or execution path of a
+thread.
+
+Use it only if needed to distinguish:
+- the running path of delegated work
+- from the chronological log (`threadlog`)
+
+Do not force this term into the public surface unless it solves a concrete
+ambiguity.
+
+### threadstone
+
+A `threadstone` is a durable promoted representation of a completed or
+significant thread, used for continuity, retrieval, and MemoryGraph anchoring.
+
+Threadstones are minted, not run.
+
+Threadstones are not:
+- the coordination substrate
+- the runtime
+- the worker mesh
+- the proof pack
+- the verdict
+
+Invariant:
+- All threadstones are promoted thread summaries.
+- Some threadstones may also qualify as high-coherence wisdom nodes.
+
+This prevents `threadstone` from expanding into a vague synonym for every
+meaningful artifact.
+
+## Assay Boundary
+
+`Assay` remains the trust and proof layer.
+
+Assay owns:
+- receipts
+- proof packs
+- reviewer packets
+- verdicts
+
+Threadwork produces provenance.
+Assay evaluates proof.
+MemoryGraph preserves threadstones.
+Guardian constrains execution.
+Execution Spine runs the work.
+
+## Compatibility Notes
+
+During the migration window:
+- `AgentMesh` may remain in CLI, config, schema, trailer, and state-path
+  compatibility surfaces
+- `Threadwork` is the canonical user-facing name
+- new public narrative should prefer `Threadwork`
+- old implementation names may persist temporarily where invasive renames would
+  create unnecessary risk
+
+This is a naming and ontology freeze, not an implementation freeze.
+
+## Non-Goals
+
+This document does not:
+- rename all internals immediately
+- rename Assay receipts into Threadwork language
+- create a broad `Thread*` vocabulary family
+- require every existing `mesh` internal to be renamed on sight
+
+Restraint is intentional. `Threadwork` becomes stronger when it stays boring.
+
+## Guidance
+
+Prefer:
+- `Threadwork` for the substrate
+- `thread` for the live work unit
+- `threadlog` for chronological provenance
+- `threadstone` for promoted durable thread summaries
+- `Assay receipt` / `Assay proof pack` / `Assay verdict` for trust artifacts
+
+Avoid introducing new user-facing terms such as:
+- `Threadmark`
+- `Threadcraft`
+- `Threadfile`
+- `Threadyield`
+- `Threadply`
+- `Threadwarp`
+
+unless a future slice proves that one maps to a distinct layer that cannot be
+described clearly with the existing vocabulary.


### PR DESCRIPTION
## Summary
This is the **foundation/inventory-only** naming slice for the `AgentMesh` → `Threadwork` public rename.

- Adds `docs/naming/THREADWORK_TERMS.md` — ontology for the new naming.
- Adds `docs/naming/THREADWORK_RENAME_MEMO.md` — migration decision memo.
- Adds `docs/naming/THREADWORK_SURFACE_INVENTORY.md` — classified map of every public/compatibility-sensitive `AgentMesh` surface (`rename now` / `alias later` / `risky/needs review` / `preserve internal`), with a small baseline note explaining that the inventory's line-number evidence was captured against `handoff/m2-switch-2026-04-11`.

## Deliberately excluded
- **Narrative rename commit (`fe77cea docs: introduce Threadwork public naming`) is NOT in this PR.** That commit depends on README edits introduced in the M2 handoff (`454890e`); cherry-picking it onto `main` produces a real README conflict. Leaving it on `handoff/m2-switch-2026-04-11` until the handoff decision lands, rather than hand-resolving a merge and shipping a third artifact.
- No changes to CLI names, package names, MCP server, trailer keys, config paths, state dirs, schema enums, `.meshpack`, repo slug, or any other runtime/compatibility surface. By design — the surface inventory explicitly classifies those as `alias later` or `risky/needs review`, not `rename now`.

## Naming invariant during migration
`Threadwork` is the canonical public/narrative name. `agentmesh` remains the runtime/package/CLI/config/schema/state/trailer alias during the migration window. Do not broaden this PR's scope to touch those compatibility surfaces without an explicit compatibility plan.

## Cross-repo context
- The `assay-toolkit` side of this naming slice is already open at https://github.com/Haserjian/assay/pull/91.
- The `assay-internal` strategy doc update landed on `main` directly.

## Test plan
- [ ] `docs/naming/` directory reads as a coherent foundation (terms → memo → inventory).
- [ ] Inventory's classification is directionally correct; flag any missed public surface or mis-categorized row.
- [ ] Confirm no compatibility-surface references accidentally flagged as `rename now`.