### PR TITLE
docs: align pilot workflow with Assay 1.22

### DIFF
--- a/docs/pilot/quickstart.md
+++ b/docs/pilot/quickstart.md
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install "assay-ai @ git+https://github.com/Haserjian/assay.git@13db5ba"
+      - run: pip install "assay-ai==1.22.0"
       - name: Run evidence gate
         run: |
           mkdir -p .assay
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install "assay-ai>=1.10.1"
+      - run: pip install "assay-ai==1.22.0"
       - name: Import pinned assay signer
         env:
           ASSAY_SIGNER_KEY_B64: ${{ secrets.ASSAY_SIGNER_KEY_B64 }}

--- a/docs/pilot/starter-workflow.yml
+++ b/docs/pilot/starter-workflow.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install assay
-        run: pip install "assay-ai @ git+https://github.com/Haserjian/assay.git@13db5ba"
+        run: pip install "assay-ai==1.22.0"
 
       - name: Run evidence gate
         run: |
@@ -79,7 +79,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install assay
-        run: pip install "assay-ai>=1.10.1"
+        run: pip install "assay-ai==1.22.0"
 
       - name: Import pinned assay signer
         env:


### PR DESCRIPTION
## Summary
Unify the `pip install assay-ai` clauses in `docs/pilot/quickstart.md` and `docs/pilot/starter-workflow.yml` to the same pin, `assay-ai==1.22.0`. Scope is intentionally limited to these two files — the two surfaces a pilot team copy-pastes into their own repo.

| File:line | Before | After |
|---|---|---|
| `docs/pilot/quickstart.md:67` | `"assay-ai @ git+https://github.com/Haserjian/assay.git@13db5ba"` | `"assay-ai==1.22.0"` |
| `docs/pilot/quickstart.md:86` | `"assay-ai>=1.10.1"` | `"assay-ai==1.22.0"` |
| `docs/pilot/starter-workflow.yml:53` | `"assay-ai @ git+https://github.com/Haserjian/assay.git@13db5ba"` | `"assay-ai==1.22.0"` |
| `docs/pilot/starter-workflow.yml:82` | `"assay-ai>=1.10.1"` | `"assay-ai==1.22.0"` |

## Motivation
A pilot team copying `docs/pilot/starter-workflow.yml` today gets one job installing an old git-commit pin and another installing `>=1.10.1`, neither of which is the released 1.22.0. `docs/pilot/outreach.md:68-69` points readers at both files, so the stale pins actively propagate through every pilot invitation. Quickstart had been partially fixed earlier; starter-workflow was the remaining gap.

## Scope notes
- `docs/pilot/failure-modes.md:64` still shows `"assay-ai==1.10.1"` inside a troubleshooting example block (`### "pip install assay-ai failed"`). That's an illustrative example of "pin a version if PyPI is flaky" rather than the pilot's actual install instruction, so it's intentionally out of scope for this PR. A follow-up can bump that example for consistency if wanted.
- The outreach email (`docs/pilot/outreach.md`) doesn't mention specific versions and doesn't need to change — its links now resolve to coherent files.

## Related
Companion branch `ops/public-coherence-pass-2026-04-09` touched adjacent surfaces earlier. This PR is the focused quickstart + starter-workflow slice; reviewer can decide whether to land this first or roll into that branch.

## Test plan
- [ ] `grep -n "assay-ai" docs/pilot/quickstart.md docs/pilot/starter-workflow.yml` returns only `assay-ai==1.22.0`
- [ ] Outreach links (`docs/pilot/outreach.md:68-69`) still resolve
- [ ] Starter workflow copied into a test repo installs 1.22.0 in both jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)