### PR TITLE
docs(threadwork): clarify producer-side evidence role; resolve half-rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # AgentMesh
 
-> Internal coordination and provenance tool.
-> Not part of the customer-facing Assay evidence packet.
+> AgentMesh (public name: **Threadwork**) — producer-side agent-action evidence for Assay-ingestible reviewer packets. The runtime entry point and Python package remain `agentmesh`; `threadwork` is the public/marketing name.
+
+## Role in the constellation
+
+Threadwork produces agent-action evidence. CCIO admits which claims qualify. Assay packages them into reviewer-ready packets. Threadwork is **not** a reviewer packet — Assay is. Threadwork emits the witness/episode/lineage trailers and the export dicts that Assay's `receipt_pack.jsonl` consumes.
 
 [![PyPI](https://img.shields.io/pypi/v/agentmesh-core)](https://pypi.org/project/agentmesh-core/)
 [![Tests](https://img.shields.io/badge/tests-318%20passed-brightgreen)]()

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # AgentMesh
 
-> AgentMesh (public name: **Threadwork**) — producer-side agent-action evidence for Assay-ingestible reviewer packets. The runtime entry point and Python package remain `agentmesh`; `threadwork` is the public/marketing name.
+> Threadwork is the public-facing name for AgentMesh's producer-side evidence layer. The runtime entry point and Python package remain `agentmesh`.
 
 ## Role in the constellation
 
-Threadwork produces agent-action evidence. CCIO admits which claims qualify. Assay packages them into reviewer-ready packets. Threadwork is **not** a reviewer packet — Assay is. Threadwork emits the witness/episode/lineage trailers and the export dicts that Assay's `receipt_pack.jsonl` consumes.
+- Threadwork produces agent-action evidence.
+- CCIO admits which claims qualify.
+- Assay packages/verifies evidence into reviewer-ready packets.
+- Threadwork is not a reviewer packet; Assay owns that packet layer.
+
+Threadwork emits the witness/episode/lineage trailers and the export dicts that Assay's `receipt_pack.jsonl` consumes.
 
 [![PyPI](https://img.shields.io/pypi/v/agentmesh-core)](https://pypi.org/project/agentmesh-core/)
 [![Tests](https://img.shields.io/badge/tests-318%20passed-brightgreen)]()

--- a/docs/naming/THREADWORK_TERMS.md
+++ b/docs/naming/THREADWORK_TERMS.md
@@ -1,5 +1,7 @@
 # Threadwork Terms
 
+> **Producer/consumer relationship:** Threadwork emits evidence; Assay packages reviewer decisions. Threadwork is a separate product from Assay with a one-way producer→consumer relationship; CCIO sits between them as a claim-admission gate.
+
 Status: proposed naming freeze for migration planning.
 
 This document locks the ontology before any broad rename. It defines the

--- a/docs/naming/THREADWORK_TERMS.md
+++ b/docs/naming/THREADWORK_TERMS.md
@@ -1,6 +1,6 @@
 # Threadwork Terms
 
-> **Producer/consumer relationship:** Threadwork emits evidence; Assay packages reviewer decisions. Threadwork is a separate product from Assay with a one-way producer→consumer relationship; CCIO sits between them as a claim-admission gate.
+> **Producer/consumer relationship:** Threadwork emits evidence; CCIO admits which claims qualify; Assay packages/verifies evidence into reviewer-ready packets. Threadwork is the producer-side evidence protocol for Assay packets, not a second reviewer-facing product.
 
 Status: proposed naming freeze for migration planning.
 


### PR DESCRIPTION
## Summary
- Replaces the README opening (which had said *"internal coordination tool, not customer-facing"*) with the producer-side framing
- Adds a "Role in the constellation" section: Threadwork produces agent-action evidence; CCIO admits which claims qualify; Assay packages them into reviewer-ready packets
- Adds a one-line producer/consumer clarification at the top of `docs/naming/THREADWORK_TERMS.md`
- **Docs only.** Zero changes under `src/` or `tests/`. Code remains `agentmesh`. `grep -rn "threadwork\|Threadwork" src/ tests/` still returns zero matches.

## Why now
Resolved the half-state where `docs/naming/` declared Threadwork canonical while the README still framed AgentMesh as internal-only. The new framing makes the role explicit (producer of evidence, not the reviewer packet itself) without forcing a code-wide rename.

## Supersedes
The parked narrative-rename commit `fe77cea` on `handoff/m2-switch-2026-04-11`. That commit framed Threadwork as a standalone product face; this PR adopts the producer-side framing instead.

## Test plan
- [x] `git diff --stat` is README.md (+5/-2) and THREADWORK_TERMS.md (+2/-0) only
- [x] `grep -rln "threadwork\|Threadwork" src/ tests/` returns empty (no code drift)
- [x] Commit carries `AgentMesh-Episode`, `AgentMesh-Witness`, `AgentMesh-Sig`, `Signed-off-by` trailers (lineage + DCO + witness)
- [ ] CI: dco, lineage, public-private guard, assay-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)