### PR TITLE
feat: add guarded AgentMesh Assay proof-pack replay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,69 @@ jobs:
           path: .assay-verify/
           if-no-files-found: warn
 
+  agentmesh-assay-pack:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install AgentMesh and Assay
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,assay]"
+
+      - name: Build, verify, and replay AgentMesh Assay proof pack
+        env:
+          AGENTMESH_DATA_DIR: ${{ github.workspace }}/.agentmesh-ci
+          AGENTMESH_AGENT_ID: ci_assay_pack
+        run: |
+          set -euo pipefail
+          mkdir -p .assay-verify "$AGENTMESH_DATA_DIR"
+
+          git config user.email "agentmesh-ci@example.invalid"
+          git config user.name "AgentMesh CI"
+
+          agentmesh episode start --title "CI AgentMesh Assay proof pack"
+          EPISODE_ID="$(cat "$AGENTMESH_DATA_DIR/current_episode")"
+
+          bash scripts/episode.sh
+          test -s outputs/episode_output.json
+          test -s results.xml
+
+          git add outputs results.xml
+          agentmesh commit \
+            --message "ci canonical AgentMesh episode" \
+            --no-episode-trailer \
+            --emit-assay \
+            --assay-command assay-gate-check \
+            --assay-required
+
+          agentmesh episode assay-pack "$EPISODE_ID" \
+            --outputs outputs \
+            --results results.xml \
+            --episode-script scripts/episode.sh \
+            --out ".assay-verify/proof_pack_ci" \
+            --json \
+            | tee ".assay-verify/pack.json"
+
+          assay verify-pack ".assay-verify/proof_pack_ci" \
+            --json | tee ".assay-verify/verify.json"
+          bash ".assay-verify/proof_pack_ci/_unsigned/agentmesh/replay-from-proof.sh" \
+            ".assay-verify/proof_pack_ci" \
+            | tee ".assay-verify/replay.json"
+
+      - name: Upload AgentMesh proof-pack artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentmesh-assay-proof-pack
+          path: .assay-verify/
+          if-no-files-found: warn
+
   weave-integrity:
     runs-on: ubuntu-latest
     steps:

--- a/proto/execution.proto
+++ b/proto/execution.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+package agentmesh;
+
+// Replay contract only. Assay proof packs remain the canonical artifact format.
+message ExecutionRequest {
+  string request_id = 1;
+  string repo = 2;
+  string commit_sha = 3;
+  repeated string command = 4;
+  map<string, string> env = 5;
+  string assay_pack_format = 6;
+}
+
+message ExecutionResult {
+  string request_id = 1;
+  int32 exit_code = 2;
+  string output_manifest_sha256 = 3;
+  string proof_pack_root_sha256 = 4;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ mcp = [
 witness = [
     "cryptography>=42.0",
 ]
+assay = [
+    "assay-ai>=1.22.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/agentmesh"]

--- a/scripts/episode.sh
+++ b/scripts/episode.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUT="${AGENTMESH_OUTPUTS_DIR:-outputs}"
+RESULTS="${AGENTMESH_RESULTS_PATH:-results.xml}"
+PYTHON_BIN="${PYTHON:-python3}"
+
+mkdir -p "$OUT"
+
+"$PYTHON_BIN" - <<'PY'
+import json
+import os
+from pathlib import Path
+
+out = Path(os.environ.get("AGENTMESH_OUTPUTS_DIR", "outputs"))
+out.mkdir(parents=True, exist_ok=True)
+payload = {
+    "episode": "agentmesh-canonical-ci",
+    "claim": "AgentMesh can emit an Assay-native proof pack and replay outputs",
+    "value": 42,
+}
+(out / "episode_output.json").write_text(
+    json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+    encoding="utf-8",
+)
+PY
+
+cat > "$RESULTS" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="agentmesh_canonical_episode" tests="1" failures="0" errors="0">
+  <testcase classname="agentmesh.assay" name="canonical_episode_replayable"/>
+</testsuite>
+XML

--- a/src/agentmesh/assay_pack.py
+++ b/src/agentmesh/assay_pack.py
@@ -1,0 +1,508 @@
+"""AgentMesh -> Assay proof-pack adapter.
+
+This module deliberately delegates the proof-pack kernel to Assay. AgentMesh
+only projects episode, output, and tool-decision facts into Assay receipts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from . import __version__, db, events, gitbridge
+from .models import Event, EventKind, _now
+
+
+DEFAULT_OUTPUT_EXCLUDES = frozenset(
+    {
+        ".DS_Store",
+        "__pycache__",
+        "*.pyc",
+        "*.pyo",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+    }
+)
+
+
+@dataclass(frozen=True)
+class AgentMeshAssayPackResult:
+    pack_dir: Path
+    run_id: str
+    receipt_count: int
+    output_root_digest: str
+    sidecar_dir: Path
+
+
+def _load_assay_kernel():
+    try:
+        from assay._receipts.jcs import canonicalize as jcs_canonicalize
+        from assay.proof_pack import ProofPack
+    except ImportError as exc:
+        raise RuntimeError(
+            "Assay proof-pack support requires assay-ai. "
+            "Install agentmesh-core[assay] or install assay-ai in this environment."
+        ) from exc
+    return ProofPack, jcs_canonicalize
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_prefixed(data: bytes) -> str:
+    return "sha256:" + _sha256_hex(data)
+
+
+def _jcs_digest(obj: Any) -> str:
+    _, jcs_canonicalize = _load_assay_kernel()
+    return _sha256_prefixed(jcs_canonicalize(obj))
+
+
+def _should_exclude(rel: str, patterns: Iterable[str]) -> bool:
+    import fnmatch
+
+    parts = rel.split("/")
+    for pattern in patterns:
+        if fnmatch.fnmatch(rel, pattern):
+            return True
+        if any(fnmatch.fnmatch(part, pattern) for part in parts):
+            return True
+    return False
+
+
+def build_outputs_manifest(
+    outputs_dir: Path | str,
+    *,
+    excludes: Iterable[str] = DEFAULT_OUTPUT_EXCLUDES,
+) -> dict[str, Any]:
+    """Build a stable output manifest using Assay JCS for the root digest."""
+    root = Path(outputs_dir)
+    if not root.exists():
+        raise FileNotFoundError(f"outputs directory does not exist: {root}")
+    if not root.is_dir():
+        raise NotADirectoryError(f"outputs path is not a directory: {root}")
+
+    root_resolved = root.resolve()
+    exclude_set = sorted(set(excludes))
+    files: list[dict[str, Any]] = []
+    for path in sorted(root_resolved.rglob("*"), key=lambda p: p.relative_to(root_resolved).as_posix()):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(root_resolved).as_posix()
+        if _should_exclude(rel, exclude_set):
+            continue
+        data = path.read_bytes()
+        files.append(
+            {
+                "path": rel,
+                "sha256": _sha256_hex(data),
+                "bytes": len(data),
+            }
+        )
+
+    body = {
+        "schema": "agentmesh.outputs_manifest/v1",
+        "hash_alg": "sha256",
+        "canon": "assay.jcs-rfc8785",
+        "excludes": exclude_set,
+        "files": files,
+        "file_count": len(files),
+        "total_bytes": sum(int(f["bytes"]) for f in files),
+    }
+    return {**body, "root_digest": _jcs_digest(body)}
+
+
+def _file_manifest(path: Path) -> dict[str, Any]:
+    data = path.read_bytes()
+    return {
+        "path": path.name,
+        "sha256": _sha256_hex(data),
+        "bytes": len(data),
+    }
+
+
+def _event_episode_id(event: Event) -> str:
+    payload = event.payload or {}
+    return str(
+        payload.get("_ewp_episode_id")
+        or payload.get("episode_id")
+        or payload.get("episode")
+        or ""
+    )
+
+
+def _episode_events(episode_id: str, data_dir: Path | None) -> list[Event]:
+    return [event for event in events.read_events(data_dir) if _event_episode_id(event) == episode_id]
+
+
+def _latest_commit_sha(repo_path: Path | None, episode_id: str, data_dir: Path | None) -> str:
+    weave_events = db.list_weave_events(data_dir=data_dir, episode_id=episode_id)
+    for weave in reversed(weave_events):
+        if weave.git_commit_sha:
+            return weave.git_commit_sha
+    if repo_path and repo_path.exists():
+        sha = gitbridge._run_git(["rev-parse", "HEAD"], cwd=str(repo_path))
+        if len(sha) == 40:
+            return sha
+    return ""
+
+
+def _receipt_base(
+    *,
+    receipt_id: str,
+    receipt_type: str,
+    run_id: str,
+    seq: int,
+    timestamp: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "receipt_id": receipt_id,
+        "type": receipt_type,
+        "timestamp": timestamp,
+        "schema_version": "1.0",
+        "run_id": run_id,
+        "_trace_id": run_id,
+        "seq": seq,
+        "payload": payload,
+    }
+
+
+def _safe_assay_receipt_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    allowed = {
+        "sha",
+        "task_id",
+        "terminal_state",
+        "bridge_status",
+        "degraded_reason",
+        "command_id",
+        "tool_id",
+        "ok",
+        "returncode",
+        "guardian_decision",
+        "decision_reason",
+        "argv_digest",
+        "argv_redacted",
+        "policy_version",
+        "_ewp_version",
+        "_ewp_origin",
+        "_ewp_episode_id",
+        "_ewp_agent_id",
+    }
+    safe = {key: payload[key] for key in sorted(allowed) if key in payload}
+    if "guardian_decision_receipt" in payload:
+        safe["guardian_decision_receipt"] = payload["guardian_decision_receipt"]
+    if "gate_report" in payload:
+        report = payload["gate_report"]
+        if isinstance(report, dict):
+            safe["gate_report"] = {
+                key: report[key]
+                for key in sorted(("result", "current_score", "current_grade", "regression_detected"))
+                if key in report
+            }
+    return safe
+
+
+def build_agentmesh_receipts(
+    episode_id: str,
+    *,
+    data_dir: Path | None = None,
+    repo_path: Path | None = None,
+    outputs_manifest: dict[str, Any] | None = None,
+    results_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Project AgentMesh episode state into proof-pack-admissible receipts."""
+    episode = db.get_episode(episode_id, data_dir=data_dir)
+    if episode is None:
+        raise ValueError(f"episode not found: {episode_id}")
+
+    commit_sha = _latest_commit_sha(repo_path, episode_id, data_dir)
+    receipts: list[dict[str, Any]] = []
+
+    receipts.append(
+        _receipt_base(
+            receipt_id=f"agentmesh_episode_{episode_id}",
+            receipt_type="agentmesh.episode/v1",
+            run_id=episode_id,
+            seq=0,
+            timestamp=episode.started_at,
+            payload={
+                "episode_id": episode.episode_id,
+                "title": episode.title,
+                "started_at": episode.started_at,
+                "ended_at": episode.ended_at,
+                "parent_episode_id": episode.parent_episode_id,
+                "commit_sha": commit_sha,
+                "repo_path_present": bool(repo_path),
+                "agentmesh_version": __version__,
+            },
+        )
+    )
+
+    seq = 1
+    if outputs_manifest is not None:
+        receipts.append(
+            _receipt_base(
+                receipt_id=f"agentmesh_outputs_{episode_id}",
+                receipt_type="agentmesh.output_manifest/v1",
+                run_id=episode_id,
+                seq=seq,
+                timestamp=_now(),
+                payload={"outputs_manifest": outputs_manifest},
+            )
+        )
+        seq += 1
+
+    if results_path is not None:
+        result_file = Path(results_path)
+        if result_file.exists() and result_file.is_file():
+            receipts.append(
+                _receipt_base(
+                    receipt_id=f"agentmesh_results_{episode_id}",
+                    receipt_type="agentmesh.result_artifact/v1",
+                    run_id=episode_id,
+                    seq=seq,
+                    timestamp=_now(),
+                    payload={"result_artifact": _file_manifest(result_file)},
+                )
+            )
+            seq += 1
+
+    for weave in db.list_weave_events(data_dir=data_dir, episode_id=episode_id):
+        receipts.append(
+            _receipt_base(
+                receipt_id=f"agentmesh_weave_{weave.event_id}",
+                receipt_type="agentmesh.weave_event/v1",
+                run_id=episode_id,
+                seq=seq,
+                timestamp=weave.created_at,
+                payload=weave.model_dump(),
+            )
+        )
+        seq += 1
+
+    for event in _episode_events(episode_id, data_dir):
+        payload = event.payload or {}
+        if event.kind == EventKind.ASSAY_RECEIPT and "guardian_decision_receipt" in payload:
+            receipt_type = "agentmesh.guardian_decision/v1"
+        elif event.kind == EventKind.ASSAY_RECEIPT:
+            receipt_type = "agentmesh.assay_receipt/v1"
+        else:
+            continue
+        receipts.append(
+            _receipt_base(
+                receipt_id=f"agentmesh_event_{event.event_id}",
+                receipt_type=receipt_type,
+                run_id=episode_id,
+                seq=seq,
+                timestamp=event.ts,
+                payload={
+                    "event_id": event.event_id,
+                    "event_hash": event.event_hash,
+                    "event_kind": event.kind.value if isinstance(event.kind, EventKind) else str(event.kind),
+                    "agent_id": event.agent_id,
+                    "assay_receipt": _safe_assay_receipt_payload(payload),
+                },
+            )
+        )
+        seq += 1
+
+    return receipts
+
+
+def _write_text(path: Path, text: str, *, executable: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    if executable:
+        path.chmod(path.stat().st_mode | 0o111)
+
+
+def _write_sidecars(
+    pack_dir: Path,
+    *,
+    outputs_manifest: dict[str, Any] | None,
+    results_path: Path | None,
+    episode_script: Path | None,
+) -> Path:
+    sidecar_dir = pack_dir / "_unsigned" / "agentmesh"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+
+    if outputs_manifest is not None:
+        _write_text(
+            sidecar_dir / "outputs_manifest.json",
+            json.dumps(outputs_manifest, indent=2, sort_keys=True) + "\n",
+        )
+
+    if results_path is not None and results_path.exists() and results_path.is_file():
+        shutil.copy2(results_path, sidecar_dir / results_path.name)
+
+    if episode_script is not None and episode_script.exists() and episode_script.is_file():
+        replay_dir = sidecar_dir / "replay"
+        replay_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(episode_script, replay_dir / episode_script.name)
+
+    environment = {
+        "schema": "agentmesh.environment_lock/v1",
+        "agentmesh_version": __version__,
+        "python": sys.version,
+        "platform": platform.platform(),
+        "cwd": os.getcwd(),
+    }
+    _write_text(
+        sidecar_dir / "environment.lock.json",
+        json.dumps(environment, indent=2, sort_keys=True) + "\n",
+    )
+
+    replay = """#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -gt 0 ]]; then
+  PACK_DIR="$(cd "$1" && pwd)"
+else
+  PACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+OUTPUTS_DIR="${2:-}"
+WORKDIR=""
+
+if [[ -z "$OUTPUTS_DIR" ]]; then
+  EPISODE_SCRIPT="$PACK_DIR/_unsigned/agentmesh/replay/episode.sh"
+  if [[ -f "$EPISODE_SCRIPT" ]]; then
+    WORKDIR="$(mktemp -d)"
+    trap 'rm -rf "$WORKDIR"' EXIT
+    (
+      cd "$WORKDIR"
+      AGENTMESH_OUTPUTS_DIR="$WORKDIR/outputs" \
+      AGENTMESH_RESULTS_PATH="$WORKDIR/results.xml" \
+      bash "$EPISODE_SCRIPT"
+    )
+    OUTPUTS_DIR="$WORKDIR/outputs"
+  else
+    OUTPUTS_DIR="outputs"
+  fi
+fi
+
+python3 - "$PACK_DIR" "$OUTPUTS_DIR" <<'PY'
+import fnmatch
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+try:
+    from assay._receipts.jcs import canonicalize as jcs_canonicalize
+except ImportError:
+    print("valid:false")
+    print("assay-ai is required to recompute the signed output manifest digest", file=sys.stderr)
+    sys.exit(2)
+
+pack = Path(sys.argv[1])
+outputs = Path(sys.argv[2])
+
+expected = None
+receipt_pack = pack / "receipt_pack.jsonl"
+for line in receipt_pack.read_text(encoding="utf-8").splitlines():
+    if not line.strip():
+        continue
+    receipt = json.loads(line)
+    if receipt.get("type") == "agentmesh.output_manifest/v1":
+        expected = receipt.get("payload", {}).get("outputs_manifest")
+        break
+
+if not isinstance(expected, dict):
+    print("valid:false")
+    print("signed agentmesh.output_manifest/v1 receipt not found", file=sys.stderr)
+    sys.exit(1)
+
+files = []
+excludes = expected.get("excludes", [])
+for path in sorted(outputs.resolve().rglob("*"), key=lambda p: p.relative_to(outputs.resolve()).as_posix()):
+    if not path.is_file():
+        continue
+    rel = path.relative_to(outputs.resolve()).as_posix()
+    parts = rel.split("/")
+    if any(fnmatch.fnmatch(rel, pat) or any(fnmatch.fnmatch(part, pat) for part in parts) for pat in excludes):
+        continue
+    data = path.read_bytes()
+    files.append({"path": rel, "sha256": hashlib.sha256(data).hexdigest(), "bytes": len(data)})
+
+actual = {
+    "schema": expected.get("schema"),
+    "hash_alg": expected.get("hash_alg"),
+    "canon": expected.get("canon"),
+    "excludes": excludes,
+    "files": files,
+    "file_count": len(files),
+    "total_bytes": sum(int(item["bytes"]) for item in files),
+}
+actual_root = "sha256:" + hashlib.sha256(jcs_canonicalize(actual)).hexdigest()
+
+if actual_root != expected.get("root_digest"):
+    print("valid:false")
+    print(
+        f"output manifest root mismatch: expected={expected.get('root_digest')} actual={actual_root}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+print("valid:true")
+PY
+"""
+    _write_text(sidecar_dir / "replay-from-proof.sh", replay, executable=True)
+    return sidecar_dir
+
+
+def build_agentmesh_assay_pack(
+    episode_id: str,
+    output_dir: Path,
+    *,
+    data_dir: Path | None = None,
+    repo_path: Path | None = None,
+    outputs_dir: Path | None = None,
+    results_path: Path | None = None,
+    episode_script: Path | None = None,
+    mode: str = "shadow",
+    keystore: Any = None,
+) -> AgentMeshAssayPackResult:
+    """Build an Assay proof pack for an AgentMesh episode."""
+    ProofPack, _ = _load_assay_kernel()
+    outputs_manifest = (
+        build_outputs_manifest(outputs_dir)
+        if outputs_dir is not None
+        else None
+    )
+    receipts = build_agentmesh_receipts(
+        episode_id,
+        data_dir=data_dir,
+        repo_path=repo_path,
+        outputs_manifest=outputs_manifest,
+        results_path=results_path,
+    )
+    pack = ProofPack(
+        run_id=episode_id,
+        entries=receipts,
+        mode=mode,
+        suite_id="agentmesh-episode",
+        claim_set_id="agentmesh-proof-pack-adapter-v1",
+    )
+    pack_dir = pack.build(output_dir, keystore=keystore)
+    sidecar_dir = _write_sidecars(
+        pack_dir,
+        outputs_manifest=outputs_manifest,
+        results_path=results_path,
+        episode_script=episode_script,
+    )
+    return AgentMeshAssayPackResult(
+        pack_dir=pack_dir,
+        run_id=episode_id,
+        receipt_count=len(receipts),
+        output_root_digest=str(outputs_manifest.get("root_digest", "")) if outputs_manifest else "",
+        sidecar_dir=sidecar_dir,
+    )

--- a/src/agentmesh/cli.py
+++ b/src/agentmesh/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import shutil
 import subprocess
@@ -25,6 +26,11 @@ console = Console()
 
 _DATA_DIR: Path | None = None
 EPISODE_TRAILER_KEY = "AgentMesh-Episode"
+ASSAY_HOOK_POLICY_VERSION = "agentmesh.assay_hook/v1"
+ASSAY_HOOK_TOOL_ID = "agentmesh.assay_hook"
+_ASSAY_HOOK_DEFAULT_COMMAND = "assay-gate-check"
+_ASSAY_HOOK_COMMANDS = {"assay-gate-check", "assay-receipt-emit"}
+_SHELL_METACHARS = frozenset(";&|<>()`$\\\n\r")
 
 
 def _get_data_dir() -> Path | None:
@@ -114,6 +120,94 @@ def _policy_get(policy: dict[str, Any], keys: list[str], default: Any) -> Any:
             return default
         value = value[key]
     return value
+
+
+def _stable_json_digest(obj: Any) -> str:
+    data = json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return "sha256:" + hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def _redact_assay_argv(argv: list[str], repo_path: Path) -> list[str]:
+    repo = str(repo_path)
+    return ["<repo>" if arg == repo else arg for arg in argv]
+
+
+def _assay_hook_decision_receipt(
+    *,
+    command_id: str,
+    input_origin: str,
+    guardian_decision: str,
+    decision_reason: str,
+    repo_path: Path,
+    argv: list[str] | None = None,
+    rejected_command_digest: str = "",
+) -> dict[str, Any]:
+    redacted = _redact_assay_argv(argv or [], repo_path)
+    receipt: dict[str, Any] = {
+        "schema": "agentmesh.guardian_tool_decision/v1",
+        "tool_id": ASSAY_HOOK_TOOL_ID,
+        "command_id": command_id,
+        "input_origin": input_origin,
+        "guardian_decision": guardian_decision,
+        "decision_reason": decision_reason,
+        "argv_digest": _stable_json_digest(argv or []),
+        "argv_redacted": redacted,
+        "redaction_policy": "assay.argv_redaction/v1",
+        "policy_version": ASSAY_HOOK_POLICY_VERSION,
+    }
+    if rejected_command_digest:
+        receipt["rejected_command_digest"] = rejected_command_digest
+    return receipt
+
+
+def _resolve_assay_hook_command(
+    command_id: str,
+    *,
+    repo_path: Path,
+    input_origin: str,
+) -> tuple[list[str] | None, dict[str, Any]]:
+    """Resolve an Assay hook command preset into structured argv.
+
+    The commit hook is part of the proof boundary, so it accepts only named
+    presets. Raw shell strings are denied and recorded without logging the raw
+    command text.
+    """
+    normalized = command_id.strip() or _ASSAY_HOOK_DEFAULT_COMMAND
+    rejected_digest = _stable_json_digest({"command": normalized})
+
+    if any(ch in normalized for ch in _SHELL_METACHARS):
+        return None, _assay_hook_decision_receipt(
+            command_id="rejected",
+            input_origin=input_origin,
+            guardian_decision="deny",
+            decision_reason="shell_metacharacter_forbidden",
+            repo_path=repo_path,
+            rejected_command_digest=rejected_digest,
+        )
+
+    if normalized not in _ASSAY_HOOK_COMMANDS:
+        return None, _assay_hook_decision_receipt(
+            command_id="rejected",
+            input_origin=input_origin,
+            guardian_decision="deny",
+            decision_reason="unregistered_assay_command_preset",
+            repo_path=repo_path,
+            rejected_command_digest=rejected_digest,
+        )
+
+    if normalized == "assay-gate-check":
+        argv = ["assay", "gate", "check", str(repo_path), "--min-score", "0", "--json"]
+    else:
+        argv = ["assay", "receipt", "emit"]
+
+    return argv, _assay_hook_decision_receipt(
+        command_id=normalized,
+        input_origin=input_origin,
+        guardian_decision="allow",
+        decision_reason="registered_assay_command_preset",
+        repo_path=repo_path,
+        argv=argv,
+    )
 
 
 def _write_scaffold_file(path: Path, content: str, force: bool) -> str:
@@ -1141,6 +1235,70 @@ def episode_import_cmd(
     console.print(f"Imported: {counts}")
 
 
+@episode_app.command(name="assay-pack")
+def episode_assay_pack_cmd(
+    episode_id: Optional[str] = typer.Argument(None, help="Episode ID. Defaults to current episode."),
+    out: Optional[str] = typer.Option(None, "--out", "-o", help="Output proof-pack directory"),
+    outputs: Optional[str] = typer.Option(None, "--outputs", help="Episode outputs directory to manifest"),
+    results: Optional[str] = typer.Option(None, "--results", help="Result artifact, e.g. results.xml"),
+    episode_script: Optional[str] = typer.Option(None, "--episode-script", help="Canonical episode script sidecar"),
+    repo: Optional[str] = typer.Option(None, "--repo", help="Repository path for commit provenance"),
+    mode: str = typer.Option("shadow", "--mode", help="Assay pack mode: shadow|enforced|breakglass"),
+    json_out: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Build an Assay proof pack from AgentMesh episode receipts."""
+    _ensure_db()
+    target_episode = episode_id or episodes.get_current_episode(_get_data_dir())
+    if not target_episode:
+        console.print("[red]No episode supplied and no current episode is active[/red]")
+        raise typer.Exit(1)
+
+    out_path = Path(out) if out else Path(f"proof_pack_{target_episode}")
+    repo_path = Path(repo).resolve() if repo else (Path.cwd() if gitbridge.is_git_repo(os.getcwd()) else None)
+    outputs_path = Path(outputs).resolve() if outputs else None
+    results_path = Path(results).resolve() if results else None
+    script_path = Path(episode_script).resolve() if episode_script else None
+
+    try:
+        from .assay_pack import build_agentmesh_assay_pack
+
+        result = build_agentmesh_assay_pack(
+            target_episode,
+            out_path,
+            data_dir=_get_data_dir(),
+            repo_path=repo_path,
+            outputs_dir=outputs_path,
+            results_path=results_path,
+            episode_script=script_path,
+            mode=mode,
+        )
+    except (RuntimeError, ValueError, OSError) as exc:
+        if json_out:
+            console.print(json.dumps({"status": "error", "error": str(exc)}))
+        else:
+            console.print(f"[red]Error:[/] {exc}")
+        raise typer.Exit(1)
+
+    payload = {
+        "status": "ok",
+        "episode_id": result.run_id,
+        "pack_dir": str(result.pack_dir),
+        "receipt_count": result.receipt_count,
+        "output_root_digest": result.output_root_digest,
+        "sidecar_dir": str(result.sidecar_dir),
+        "verify_command": f"assay verify-pack {result.pack_dir}",
+    }
+    if json_out:
+        console.print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    console.print(f"Assay proof pack: [bold]{result.pack_dir}[/bold]")
+    console.print(f"  episode={result.run_id}")
+    console.print(f"  receipts={result.receipt_count}")
+    if result.output_root_digest:
+        console.print(f"  outputs={result.output_root_digest}")
+    console.print(f"  verify: assay verify-pack {result.pack_dir}")
+
+
 # -- Wait/Steal commands --
 
 @app.command()
@@ -1211,7 +1369,7 @@ def commit_cmd(
     capsule: bool = typer.Option(False, "--capsule", help="Also emit a context capsule"),
     signoff: bool = typer.Option(False, "--signoff", "-S", help="Add Signed-off-by trailer (DCO)"),
     emit_assay: bool = typer.Option(False, "--emit-assay", help="Emit optional Assay receipt after commit"),
-    assay_command: str = typer.Option("", "--assay-command", help="Override Assay command (shell)"),
+    assay_command: str = typer.Option("", "--assay-command", help="Assay hook preset, e.g. assay-gate-check"),
     assay_timeout_s: int = typer.Option(30, "--assay-timeout", help="Assay command timeout seconds"),
     assay_required: bool = typer.Option(False, "--assay-required", help="Exit 7 (partial success) if Assay emit fails after commit succeeds"),
 ) -> None:
@@ -1317,15 +1475,22 @@ def commit_cmd(
     if not isinstance(assay_cfg, dict):
         assay_cfg = {}
     assay_enabled = emit_assay or bool(assay_cfg.get("emit_on_commit", False))
-    assay_cmd = assay_command.strip() or str(assay_cfg.get("command", "")).strip()
+    assay_cli_command = assay_command.strip()
+    assay_cfg_command = str(
+        assay_cfg.get("preset", assay_cfg.get("command", ""))
+    ).strip()
+    assay_command_id = assay_cli_command or assay_cfg_command or _ASSAY_HOOK_DEFAULT_COMMAND
+    assay_input_origin = (
+        "human_cli"
+        if assay_cli_command
+        else str(assay_cfg.get("input_origin", "repo_policy" if assay_cfg else "default"))
+    )
     cfg_timeout = assay_cfg.get("timeout_s", 30)
     cfg_timeout_s = cfg_timeout if isinstance(cfg_timeout, int) else 30
     effective_assay_timeout = assay_timeout_s if assay_timeout_s > 0 else max(cfg_timeout_s, 1)
     assay_hard_fail = assay_required or bool(assay_cfg.get("required", False))
 
     if assay_enabled:
-        if not assay_cmd:
-            assay_cmd = "assay receipt emit"
         episode_id = episodes.get_current_episode(_get_data_dir()) or ""
         env = {
             **os.environ,
@@ -1342,23 +1507,37 @@ def commit_cmd(
         assay_stdout = ""
         assay_stderr = ""
         assay_error = ""
-        try:
-            proc = subprocess.run(
-                assay_cmd,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=effective_assay_timeout,
-                cwd=cwd,
-                env=env,
-            )
-            returncode = proc.returncode
-            assay_stdout = (proc.stdout or "").strip()
-            assay_stderr = (proc.stderr or "").strip()
-        except subprocess.TimeoutExpired:
-            assay_error = f"assay command timed out after {effective_assay_timeout}s"
-        except OSError as exc:
-            assay_error = str(exc)
+        assay_argv, decision_receipt = _resolve_assay_hook_command(
+            assay_command_id,
+            repo_path=Path(cwd),
+            input_origin=assay_input_origin,
+        )
+        if decision_receipt["guardian_decision"] == "deny":
+            returncode = 126
+            assay_error = decision_receipt["decision_reason"]
+        else:
+            try:
+                proc = subprocess.run(
+                    assay_argv,
+                    shell=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=effective_assay_timeout,
+                    cwd=cwd,
+                    env=env,
+                )
+                returncode = proc.returncode
+                assay_stdout = (proc.stdout or "").strip()
+                assay_stderr = (proc.stderr or "").strip()
+            except subprocess.TimeoutExpired:
+                assay_error = f"assay command timed out after {effective_assay_timeout}s"
+            except OSError as exc:
+                assay_error = str(exc)
+                decision_receipt = {
+                    **decision_receipt,
+                    "guardian_decision": "deny",
+                    "decision_reason": "assay_command_start_failed",
+                }
 
         assay_ok = returncode == 0 and not assay_error
         events.append_event(
@@ -1366,12 +1545,25 @@ def commit_cmd(
             agent_id=agent_id,
             payload={
                 "sha": sha,
-                "command": assay_cmd,
+                "command": decision_receipt["command_id"],
+                "command_id": decision_receipt["command_id"],
+                "tool_id": decision_receipt["tool_id"],
                 "ok": assay_ok,
                 "returncode": returncode,
                 "stdout": assay_stdout[-1000:],
                 "stderr": assay_stderr[-1000:],
                 "error": assay_error,
+                "guardian_decision_receipt": decision_receipt,
+                "guardian_decision": decision_receipt["guardian_decision"],
+                "decision_reason": decision_receipt["decision_reason"],
+                "argv_digest": decision_receipt["argv_digest"],
+                "argv_redacted": decision_receipt["argv_redacted"],
+                "policy_version": decision_receipt["policy_version"],
+                # Evidence Wire Protocol v0 envelope
+                "_ewp_version": "0",
+                "_ewp_origin": "agentmesh/assay_commit_hook",
+                "_ewp_episode_id": episode_id,
+                "_ewp_agent_id": agent_id,
             },
             data_dir=_get_data_dir(),
         )

--- a/src/agentmesh/gitbridge.py
+++ b/src/agentmesh/gitbridge.py
@@ -114,6 +114,8 @@ def run_tests(command: str, cwd: str | None = None) -> tuple[bool, str]:
 
     Summary is last 20 lines of combined output.
     """
+    # Boundary note: this is an explicit developer-local command surface, not
+    # an Assay/Guardian trust-evidence path. Keep shell=True confined here.
     try:
         result = subprocess.run(
             command, shell=True, capture_output=True, text=True,

--- a/tests/test_assay_bridge.py
+++ b/tests/test_assay_bridge.py
@@ -259,11 +259,10 @@ def test_bridge_always_emits_event_ok(data_dir, repo_dir):
 
 # -- 9. Event always emitted on DEGRADED --
 
-def test_bridge_always_emits_event_degraded(data_dir):
-    # Stub Path.cwd() to a temp dir without .git so the CWD fallback in
-    # _find_repo_path doesn't accidentally resolve a real git repo and
-    # succeed when assay is installed locally.
-    with patch.object(Path, "cwd", return_value=data_dir):
+def test_bridge_always_emits_event_degraded(data_dir, tmp_path):
+    non_git = tmp_path / "not_a_repo"
+    non_git.mkdir()
+    with patch("agentmesh.assay_bridge.Path.cwd", return_value=non_git):
         emit_bridge_event(
             task_id="task_evt_deg",
             terminal_state="ABORTED",

--- a/tests/test_assay_pack.py
+++ b/tests/test_assay_pack.py
@@ -1,0 +1,207 @@
+"""Tests for AgentMesh -> Assay proof-pack adapter."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from agentmesh import db, events, episodes
+from agentmesh.assay_pack import (
+    build_agentmesh_assay_pack,
+    build_agentmesh_receipts,
+    build_outputs_manifest,
+)
+from agentmesh.models import EventKind
+
+
+pytest.importorskip("assay.proof_pack")
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", str(tmp_path)], capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=str(tmp_path), capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=str(tmp_path), capture_output=True, check=True)
+    (tmp_path / "init.txt").write_text("init\n")
+    subprocess.run(["git", "add", "init.txt"], cwd=str(tmp_path), capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(tmp_path), capture_output=True, check=True)
+    return tmp_path
+
+
+def test_outputs_manifest_is_stable_and_uses_assay_canon(tmp_path: Path) -> None:
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+    (outputs / "b.txt").write_text("b\n")
+    (outputs / "a.txt").write_text("a\n")
+    (outputs / "__pycache__").mkdir()
+    (outputs / "__pycache__" / "ignored.pyc").write_bytes(b"ignored")
+
+    first = build_outputs_manifest(outputs)
+    second = build_outputs_manifest(outputs)
+
+    assert first == second
+    assert first["canon"] == "assay.jcs-rfc8785"
+    assert first["root_digest"].startswith("sha256:")
+    assert [item["path"] for item in first["files"]] == ["a.txt", "b.txt"]
+
+
+def test_build_agentmesh_receipts_projects_guardian_decisions(
+    tmp_path: Path,
+    tmp_data_dir: Path,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    episode_id = episodes.start_episode("adapter test", data_dir=tmp_data_dir)
+    events.append_event(
+        EventKind.ASSAY_RECEIPT,
+        agent_id="agent_1",
+        payload={
+            "_ewp_episode_id": episode_id,
+            "_ewp_origin": "agentmesh/assay_commit_hook",
+            "sha": "a" * 40,
+            "ok": False,
+            "returncode": 126,
+            "guardian_decision_receipt": {
+                "schema": "agentmesh.guardian_tool_decision/v1",
+                "tool_id": "agentmesh.assay_hook",
+                "command_id": "rejected",
+                "input_origin": "model_suggested",
+                "guardian_decision": "deny",
+                "decision_reason": "shell_metacharacter_forbidden",
+                "argv_digest": "sha256:" + "1" * 64,
+                "argv_redacted": [],
+                "policy_version": "agentmesh.assay_hook/v1",
+            },
+        },
+        data_dir=tmp_data_dir,
+    )
+
+    receipts = build_agentmesh_receipts(
+        episode_id,
+        data_dir=tmp_data_dir,
+        repo_path=repo,
+        outputs_manifest={"schema": "agentmesh.outputs_manifest/v1", "root_digest": "sha256:" + "2" * 64},
+    )
+
+    receipt_types = {receipt["type"] for receipt in receipts}
+    assert "agentmesh.episode/v1" in receipt_types
+    assert "agentmesh.output_manifest/v1" in receipt_types
+    assert "agentmesh.guardian_decision/v1" in receipt_types
+    guardian = next(receipt for receipt in receipts if receipt["type"] == "agentmesh.guardian_decision/v1")
+    assert guardian["payload"]["assay_receipt"]["guardian_decision_receipt"]["guardian_decision"] == "deny"
+    assert "stdout" not in guardian["payload"]["assay_receipt"]
+
+
+def test_build_agentmesh_assay_pack_uses_assay_verifier(
+    tmp_path: Path,
+    tmp_data_dir: Path,
+) -> None:
+    from assay.keystore import AssayKeyStore, DEFAULT_SIGNER_ID
+    from assay.proof_pack import verify_proof_pack
+
+    repo = _init_repo(tmp_path / "repo")
+    outputs = repo / "outputs"
+    outputs.mkdir()
+    (outputs / "episode_output.json").write_text('{"ok":true}\n')
+    results = repo / "results.xml"
+    results.write_text("<testsuite tests='1' failures='0'></testsuite>\n")
+    script = repo / "episode.sh"
+    script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+OUT="${AGENTMESH_OUTPUTS_DIR:-outputs}"
+RESULTS="${AGENTMESH_RESULTS_PATH:-results.xml}"
+mkdir -p "$OUT"
+printf '{"ok":true}\\n' > "$OUT/episode_output.json"
+printf "<testsuite tests='1' failures='0'></testsuite>\\n" > "$RESULTS"
+"""
+    )
+
+    episode_id = episodes.start_episode("pack build", data_dir=tmp_data_dir)
+    events.append_event(
+        EventKind.ASSAY_RECEIPT,
+        agent_id="agent_1",
+        payload={
+            "_ewp_episode_id": episode_id,
+            "_ewp_origin": "agentmesh/assay_commit_hook",
+            "command_id": "assay-gate-check",
+            "tool_id": "agentmesh.assay_hook",
+            "ok": True,
+            "returncode": 0,
+            "guardian_decision_receipt": {
+                "schema": "agentmesh.guardian_tool_decision/v1",
+                "tool_id": "agentmesh.assay_hook",
+                "command_id": "assay-gate-check",
+                "input_origin": "repo_policy",
+                "guardian_decision": "allow",
+                "decision_reason": "registered_assay_command_preset",
+                "argv_digest": "sha256:" + "3" * 64,
+                "argv_redacted": ["assay", "gate", "check", "<repo>", "--min-score", "0", "--json"],
+                "policy_version": "agentmesh.assay_hook/v1",
+            },
+        },
+        data_dir=tmp_data_dir,
+    )
+
+    keystore = AssayKeyStore(keys_dir=tmp_path / "keys")
+    keystore.ensure_key(DEFAULT_SIGNER_ID)
+    result = build_agentmesh_assay_pack(
+        episode_id,
+        tmp_path / "proof_pack",
+        data_dir=tmp_data_dir,
+        repo_path=repo,
+        outputs_dir=outputs,
+        results_path=results,
+        episode_script=script,
+        keystore=keystore,
+    )
+
+    manifest = json.loads((result.pack_dir / "pack_manifest.json").read_text())
+    verify = verify_proof_pack(manifest, result.pack_dir, keystore)
+    assert verify.passed, [error.to_dict() for error in verify.errors]
+
+    cli_verify = subprocess.run(
+        [sys.executable, "-m", "assay.cli", "verify-pack", str(result.pack_dir), "--json"],
+        capture_output=True,
+        text=True,
+    )
+    assert cli_verify.returncode == 0, cli_verify.stdout + cli_verify.stderr
+
+    receipt_lines = [
+        json.loads(line)
+        for line in (result.pack_dir / "receipt_pack.jsonl").read_text().splitlines()
+        if line.strip()
+    ]
+    assert {receipt["type"] for receipt in receipt_lines} >= {
+        "agentmesh.episode/v1",
+        "agentmesh.output_manifest/v1",
+        "agentmesh.result_artifact/v1",
+        "agentmesh.guardian_decision/v1",
+    }
+
+    sidecar_manifest = json.loads(
+        (result.pack_dir / "_unsigned" / "agentmesh" / "outputs_manifest.json").read_text()
+    )
+    output_receipt = next(receipt for receipt in receipt_lines if receipt["type"] == "agentmesh.output_manifest/v1")
+    assert sidecar_manifest["root_digest"] == result.output_root_digest
+    assert output_receipt["payload"]["outputs_manifest"]["root_digest"] == result.output_root_digest
+
+    replay = result.pack_dir / "_unsigned" / "agentmesh" / "replay-from-proof.sh"
+    assert replay.exists()
+    assert (result.pack_dir / "_unsigned" / "agentmesh" / "replay" / "episode.sh").exists()
+    sidecar_manifest_path = result.pack_dir / "_unsigned" / "agentmesh" / "outputs_manifest.json"
+    sidecar_manifest_path.write_text('{"tampered": true}\n')
+    replay_result = subprocess.run(
+        [
+            "bash",
+            str(replay.relative_to(result.pack_dir.parent)),
+            result.pack_dir.name,
+        ],
+        cwd=result.pack_dir.parent,
+        capture_output=True,
+        text=True,
+    )
+    assert replay_result.returncode == 0, replay_result.stdout + replay_result.stderr
+    assert "valid:true" in replay_result.stdout

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -16,6 +17,31 @@ from agentmesh.models import EventKind
 from agentmesh.weaver import append_weave, export_weave_md, verify_weave
 
 runner = CliRunner()
+_REAL_SUBPROCESS_RUN = subprocess.run
+
+
+def _mock_assay_subprocess(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    def _run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "assay":
+            return subprocess.CompletedProcess(
+                args=list(cmd),
+                returncode=returncode,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        return _REAL_SUBPROCESS_RUN(cmd, *args, **kwargs)
+
+    return _run
+
+
+def _assay_subprocess_calls(mock_run):
+    return [
+        call for call in mock_run.call_args_list
+        if call.args
+        and isinstance(call.args[0], (list, tuple))
+        and call.args[0]
+        and call.args[0][0] == "assay"
+    ]
 
 
 def _init_repo(tmp_path: Path) -> Path:
@@ -259,11 +285,11 @@ def test_weave_verify_beyond_100_events(tmp_data_dir: Path) -> None:
     assert valid, err
 
 
-def test_cli_commit_emits_assay_receipt_event(tmp_path: Path, tmp_data_dir: Path, monkeypatch) -> None:
+def test_allows_named_assay_gate_preset(tmp_path: Path, tmp_data_dir: Path, monkeypatch) -> None:
     repo = _init_repo(tmp_path / "repo")
     (repo / ".agentmesh").mkdir(parents=True, exist_ok=True)
     (repo / ".agentmesh" / "policy.json").write_text(
-        '{"assay":{"emit_on_commit":true,"command":"python3 -c \\"print(123)\\""}}'
+        '{"assay":{"emit_on_commit":true,"command":"assay-gate-check"}}'
     )
     (repo / "with_assay.py").write_text("print('x')\n")
     subprocess.run(["git", "add", "with_assay.py"], cwd=str(repo), capture_output=True, check=True)
@@ -271,13 +297,49 @@ def test_cli_commit_emits_assay_receipt_event(tmp_path: Path, tmp_data_dir: Path
     monkeypatch.chdir(repo)
     monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
     monkeypatch.setenv("AGENTMESH_AGENT_ID", "assay_agent")
-    result = runner.invoke(app, ["commit", "-m", "with assay", "--no-episode-trailer"])
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess(returncode=0, stdout='{"ok":true}')
+        result = runner.invoke(app, ["commit", "-m", "with assay", "--no-episode-trailer"])
     assert result.exit_code == 0, result.output
 
     evts = events.read_events(data_dir=tmp_data_dir)
     assay_evts = [e for e in evts if e.kind == EventKind.ASSAY_RECEIPT]
     assert len(assay_evts) == 1
-    assert assay_evts[0].payload["ok"] is True
+    payload = assay_evts[0].payload
+    decision = payload["guardian_decision_receipt"]
+    assert payload["ok"] is True
+    assert payload["command_id"] == "assay-gate-check"
+    assert decision["guardian_decision"] == "allow"
+    assert decision["decision_reason"] == "registered_assay_command_preset"
+    assert decision["argv_redacted"] == [
+        "assay", "gate", "check", "<repo>", "--min-score", "0", "--json",
+    ]
+
+
+def test_allowed_command_uses_shell_false(tmp_path: Path, tmp_data_dir: Path, monkeypatch) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "with_assay.py").write_text("print('x')\n")
+    subprocess.run(["git", "add", "with_assay.py"], cwd=str(repo), capture_output=True, check=True)
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
+    monkeypatch.setenv("AGENTMESH_AGENT_ID", "assay_agent")
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess(returncode=0, stdout='{"ok":true}')
+        result = runner.invoke(
+            app,
+            [
+                "commit", "-m", "with assay", "--no-episode-trailer",
+                "--emit-assay", "--assay-command", "assay-gate-check",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assay_calls = _assay_subprocess_calls(mock_run)
+    assert len(assay_calls) == 1
+    args, kwargs = assay_calls[0]
+    assert args[0] == ["assay", "gate", "check", str(repo), "--min-score", "0", "--json"]
+    assert kwargs["shell"] is False
 
 
 def test_cli_commit_assay_failure_is_non_blocking_by_default(
@@ -288,7 +350,7 @@ def test_cli_commit_assay_failure_is_non_blocking_by_default(
     repo = _init_repo(tmp_path / "repo")
     (repo / ".agentmesh").mkdir(parents=True, exist_ok=True)
     (repo / ".agentmesh" / "policy.json").write_text(
-        '{"assay":{"emit_on_commit":true,"command":"false","required":false}}'
+        '{"assay":{"emit_on_commit":true,"command":"assay-gate-check","required":false}}'
     )
     (repo / "assay_fail.py").write_text("print('x')\n")
     subprocess.run(["git", "add", "assay_fail.py"], cwd=str(repo), capture_output=True, check=True)
@@ -296,7 +358,9 @@ def test_cli_commit_assay_failure_is_non_blocking_by_default(
     monkeypatch.chdir(repo)
     monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
     monkeypatch.setenv("AGENTMESH_AGENT_ID", "assay_agent")
-    result = runner.invoke(app, ["commit", "-m", "assay fails", "--no-episode-trailer"])
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess(returncode=1, stderr="gate failed")
+        result = runner.invoke(app, ["commit", "-m", "assay fails", "--no-episode-trailer"])
     assert result.exit_code == 0, result.output
 
     evts = events.read_events(data_dir=tmp_data_dir)
@@ -312,7 +376,7 @@ def test_cli_commit_assay_required_fails_command(tmp_path: Path, tmp_data_dir: P
     repo = _init_repo(tmp_path / "repo")
     (repo / ".agentmesh").mkdir(parents=True, exist_ok=True)
     (repo / ".agentmesh" / "policy.json").write_text(
-        '{"assay":{"emit_on_commit":true,"command":"false","required":true}}'
+        '{"assay":{"emit_on_commit":true,"command":"assay-gate-check","required":true}}'
     )
     (repo / "assay_required.py").write_text("print('x')\n")
     subprocess.run(["git", "add", "assay_required.py"], cwd=str(repo), capture_output=True, check=True)
@@ -320,7 +384,9 @@ def test_cli_commit_assay_required_fails_command(tmp_path: Path, tmp_data_dir: P
     monkeypatch.chdir(repo)
     monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
     monkeypatch.setenv("AGENTMESH_AGENT_ID", "assay_agent")
-    result = runner.invoke(app, ["commit", "-m", "assay required", "--no-episode-trailer"])
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess(returncode=1, stderr="gate failed")
+        result = runner.invoke(app, ["commit", "-m", "assay required", "--no-episode-trailer"])
 
     # Exit 7 = partial success (commit succeeded, assay emission failed)
     assert result.exit_code == 7
@@ -362,7 +428,7 @@ def test_cli_commit_assay_required_partial_success_commit_in_history(
     repo = _init_repo(tmp_path / "repo")
     (repo / ".agentmesh").mkdir(parents=True, exist_ok=True)
     (repo / ".agentmesh" / "policy.json").write_text(
-        '{"assay":{"emit_on_commit":true,"command":"false","required":true}}'
+        '{"assay":{"emit_on_commit":true,"command":"assay-gate-check","required":true}}'
     )
     (repo / "partial.py").write_text("partial = True\n")
     subprocess.run(["git", "add", "partial.py"], cwd=str(repo), capture_output=True, check=True)
@@ -376,7 +442,9 @@ def test_cli_commit_assay_required_partial_success_commit_in_history(
     monkeypatch.chdir(repo)
     monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
     monkeypatch.setenv("AGENTMESH_AGENT_ID", "partial_agent")
-    result = runner.invoke(app, ["commit", "-m", "partial test", "--no-episode-trailer"])
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess(returncode=1, stderr="gate failed")
+        result = runner.invoke(app, ["commit", "-m", "partial test", "--no-episode-trailer"])
     assert result.exit_code == 7  # partial success, NOT 1
 
     # Count commits after -- must be exactly one more
@@ -405,13 +473,15 @@ def test_cli_commit_assay_required_via_flag(
     monkeypatch.chdir(repo)
     monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
     monkeypatch.setenv("AGENTMESH_AGENT_ID", "flag_agent")
-    result = runner.invoke(app, [
-        "commit", "-m", "flag required",
-        "--emit-assay",
-        "--assay-command", "false",
-        "--assay-required",
-        "--no-episode-trailer",
-    ])
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess(returncode=1, stderr="gate failed")
+        result = runner.invoke(app, [
+            "commit", "-m", "flag required",
+            "--emit-assay",
+            "--assay-command", "assay-gate-check",
+            "--assay-required",
+            "--no-episode-trailer",
+        ])
     assert result.exit_code == 7
 
     # Commit must exist
@@ -511,3 +581,78 @@ def test_cli_bridge_emit_json_output(tmp_path: Path, tmp_data_dir: Path, monkeyp
     assert parsed["schema_version"] == "1"
     assert "bridge_status" in parsed
     assert parsed["bridge_status"] in ("BRIDGE_EMIT_OK", "BRIDGE_EMIT_DEGRADED")
+
+
+def test_denies_assay_command_shell_injection(
+    tmp_path: Path,
+    tmp_data_dir: Path,
+    monkeypatch,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    (repo / "assay_injection.py").write_text("print('x')\n")
+    subprocess.run(["git", "add", "assay_injection.py"], cwd=str(repo), capture_output=True, check=True)
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
+    monkeypatch.setenv("AGENTMESH_AGENT_ID", "assay_agent")
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess()
+        result = runner.invoke(
+            app,
+            [
+                "commit", "-m", "assay denied", "--no-episode-trailer",
+                "--emit-assay", "--assay-command", "assay-gate-check; touch pwned",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert _assay_subprocess_calls(mock_run) == []
+    assert not (repo / "pwned").exists()
+
+    evts = events.read_events(data_dir=tmp_data_dir)
+    assay_evts = [e for e in evts if e.kind == EventKind.ASSAY_RECEIPT]
+    assert len(assay_evts) == 1
+    payload = assay_evts[0].payload
+    decision = payload["guardian_decision_receipt"]
+    assert payload["ok"] is False
+    assert payload["returncode"] == 126
+    assert decision["guardian_decision"] == "deny"
+    assert decision["decision_reason"] == "shell_metacharacter_forbidden"
+    assert decision["command_id"] == "rejected"
+    assert "rejected_command_digest" in decision
+
+
+def test_denied_command_emits_decision_receipt(
+    tmp_path: Path,
+    tmp_data_dir: Path,
+    monkeypatch,
+) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    (repo / ".agentmesh").mkdir(parents=True, exist_ok=True)
+    (repo / ".agentmesh" / "policy.json").write_text(
+        '{"assay":{"emit_on_commit":true,"command":"register-mcp-server","input_origin":"model_suggested"}}'
+    )
+    (repo / "assay_denied.py").write_text("print('x')\n")
+    subprocess.run(["git", "add", "assay_denied.py"], cwd=str(repo), capture_output=True, check=True)
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("AGENTMESH_DATA_DIR", str(tmp_data_dir))
+    monkeypatch.setenv("AGENTMESH_AGENT_ID", "assay_agent")
+    with patch("agentmesh.cli.subprocess.run") as mock_run:
+        mock_run.side_effect = _mock_assay_subprocess()
+        result = runner.invoke(app, ["commit", "-m", "assay denied", "--no-episode-trailer"])
+
+    assert result.exit_code == 0, result.output
+    assert _assay_subprocess_calls(mock_run) == []
+
+    evts = events.read_events(data_dir=tmp_data_dir)
+    assay_evts = [e for e in evts if e.kind == EventKind.ASSAY_RECEIPT]
+    assert len(assay_evts) == 1
+    decision = assay_evts[0].payload["guardian_decision_receipt"]
+    assert decision["schema"] == "agentmesh.guardian_tool_decision/v1"
+    assert decision["tool_id"] == "agentmesh.assay_hook"
+    assert decision["input_origin"] == "model_suggested"
+    assert decision["guardian_decision"] == "deny"
+    assert decision["decision_reason"] == "unregistered_assay_command_preset"
+    assert decision["argv_redacted"] == []
+    assert decision["argv_digest"].startswith("sha256:")

--- a/tests/test_replay_proto.py
+++ b/tests/test_replay_proto.py
@@ -1,0 +1,67 @@
+"""Tests for the AgentMesh replay proto contract.
+
+The proto deliberately references Assay output/proof-pack hashes. It must not
+become a second proof-pack or artifact container.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+PROTO_PATH = Path(__file__).parents[1] / "proto" / "execution.proto"
+
+
+def _field_names(message_body: str) -> set[str]:
+    return set(re.findall(r"\b(?:string|int32|repeated string|map<string, string>)\s+([a-z0-9_]+)\s*=", message_body))
+
+
+def test_execution_proto_is_hash_reference_contract() -> None:
+    proto = PROTO_PATH.read_text()
+    assert "message ExecutionRequest" in proto
+    assert "message ExecutionResult" in proto
+    assert "repeated bytes artifacts" not in proto
+    assert "repeated bytes signatures" not in proto
+
+    request_body = proto.split("message ExecutionRequest", 1)[1].split("message ExecutionResult", 1)[0]
+    result_body = proto.split("message ExecutionResult", 1)[1]
+
+    assert _field_names(request_body) >= {
+        "request_id",
+        "repo",
+        "commit_sha",
+        "command",
+        "env",
+        "assay_pack_format",
+    }
+    assert _field_names(result_body) == {
+        "request_id",
+        "exit_code",
+        "output_manifest_sha256",
+        "proof_pack_root_sha256",
+    }
+
+
+def test_replay_result_hashes_reference_existing_assay_output_manifest(tmp_path: Path) -> None:
+    pytest.importorskip("assay.proof_pack")
+    from agentmesh.assay_pack import build_outputs_manifest
+
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+    (outputs / "episode_output.json").write_text('{"ok":true}\n')
+
+    outputs_manifest = build_outputs_manifest(outputs)
+    proof_pack_root = "b" * 64
+    replay_result = {
+        "request_id": "req_1",
+        "exit_code": 0,
+        "output_manifest_sha256": outputs_manifest["root_digest"].removeprefix("sha256:"),
+        "proof_pack_root_sha256": proof_pack_root,
+    }
+
+    assert len(replay_result["output_manifest_sha256"]) == 64
+    assert replay_result["output_manifest_sha256"] == outputs_manifest["root_digest"].split("sha256:", 1)[1]
+    assert replay_result["proof_pack_root_sha256"] == proof_pack_root

--- a/tests/test_shell_boundaries.py
+++ b/tests/test_shell_boundaries.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src" / "agentmesh"
+ALLOWED_SHELL_TRUE = {
+    ("gitbridge.py", "run_tests"),
+}
+
+
+def test_shell_true_is_confined_to_developer_local_surfaces() -> None:
+    violations: list[str] = []
+
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        parents: dict[ast.AST, ast.AST] = {}
+        for parent in ast.walk(tree):
+            for child in ast.iter_child_nodes(parent):
+                parents[child] = parent
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_subprocess_run(node):
+                continue
+            if not _has_shell_true(node):
+                continue
+
+            rel = path.relative_to(SRC_ROOT).as_posix()
+            owner = _owner_function(node, parents)
+            if (rel, owner) not in ALLOWED_SHELL_TRUE:
+                violations.append(f"{rel}:{node.lineno} in {owner or '<module>'}")
+
+    assert violations == []
+
+
+def _is_subprocess_run(node: ast.Call) -> bool:
+    func = node.func
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "run"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    )
+
+
+def _has_shell_true(node: ast.Call) -> bool:
+    for keyword in node.keywords:
+        if keyword.arg == "shell" and isinstance(keyword.value, ast.Constant):
+            return keyword.value.value is True
+    return False
+
+
+def _owner_function(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> str:
+    current = node
+    while current in parents:
+        current = parents[current]
+        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return current.name
+    return ""

--- a/tests/test_task_flow.py
+++ b/tests/test_task_flow.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -109,6 +111,7 @@ def test_task_finish_commits_and_closes_task(
     (repo / "src").mkdir(parents=True, exist_ok=True)
     (repo / "src/auth.py").write_text("TOKEN_TIMEOUT = 30\n")
     subprocess.run(["git", "add", "src/auth.py"], cwd=str(repo), capture_output=True, check=True)
+    test_python = shlex.quote(sys.executable)
 
     finish = runner.invoke(
         app,
@@ -118,7 +121,7 @@ def test_task_finish_commits_and_closes_task(
             "--message",
             "fix auth timeout",
             "--run-tests",
-            "python3 -c 'print(123)'",
+            f"{test_python} -c 'print(123)'",
             "--no-capsule",
         ],
     )
@@ -161,7 +164,10 @@ def test_task_commands_use_policy_defaults(
         "schema_version": "1.0",
         "claims": {"ttl_seconds": 123},
         "task_finish": {
-            "run_tests": "python3 -c \"open('policy_ran.txt','w').write('ok')\"",
+            "run_tests": (
+                f"{shlex.quote(sys.executable)} "
+                "-c \"open('policy_ran.txt','w').write('ok')\""
+            ),
             "capsule": False,
             "release_all": False,
             "end_episode": False,


### PR DESCRIPTION
## Summary

Adds the first AgentMesh -> Assay proof-pack adapter path and hardens the Assay commit hook boundary.

- replaces raw Assay hook command execution with preset-only structured argv and `shell=False`
- emits Guardian-style decision receipts for allowed and denied Assay hook invocations
- adds an Assay-native AgentMesh proof-pack builder plus replay script packaged into the Assay proof pack
- adds PR-only CI coverage for AgentMesh proof-pack build, `assay verify-pack`, and replay
- adds a CONFTEST-style shell boundary check so `shell=True` stays confined to developer-local `gitbridge.run_tests`

## Verification

CONFIRMED locally:

- `git diff --cached --check`
- `PYTHONPATH=src python3 -m pytest tests/test_shell_boundaries.py tests/test_commit.py tests/test_assay_pack.py -q` -> `28 passed`
- `PYTHONPATH=src python3 -m pytest -q` -> `1 failed, 383 passed, 1 skipped`
- Base-parity check on `origin/main` for the same failing test confirmed it is pre-existing: `tests/test_provenance_export.py::TestAssayCrossValidation::test_no_duplicate_receipt_ids`
- `PYTHONPATH=src python3 -m pytest -q -k 'not test_no_duplicate_receipt_ids'` -> `383 passed, 1 skipped, 1 deselected`

## Review Scope

The only full-suite failure observed is confirmed on `origin/main` and is not introduced by this branch. This PR scope is the Assay hook command boundary, Guardian decision receipt emission, AgentMesh proof-pack assembly, and replay verification.

## Claim Boundary

This demonstrates AgentMesh episode replay through Assay proof-pack artifacts and records Guardian decisions for the Assay hook path. It does not claim all AgentMesh tool/process execution paths are policy-confined yet.
